### PR TITLE
ci: smoke + fast golden tests on push/PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Smoke test (scripts/smoke_draft.py)
+        run: printf '\n\n\n\n\n\nn\n' | python scripts/smoke_draft.py
+
+      - name: Fast golden tests
+        run: python -m pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,15 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        # Explicit bash gets -o pipefail, so a failure on either side of the
+        # smoke test's pipe fails the step.
+        shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip


### PR DESCRIPTION
## Summary  Adds `.github/workflows/ci.yml`: on every `push` and `pull_request`, a single `ubuntu-latest` / Python 3.12 job that:  1. Installs `requirements.txt` 2. Runs `scripts/smoke_draft.py` end to end (non-interactive, piped stdin) against the Smoke 4-player fixture 3. Runs `python -m pytest` (the fast golden-value suite from #6/PR #22; the slow Scotland test stays deselected via `pytest.ini`)  No matrix, no extra caching beyond `cache: pip` on `setup-python`. Both steps fail the job on nonzero exit by default (no `continue-on-error`).  Closes #7  ## Acceptance evidence  **GREEN** — push to `m1/ci` (commit f49f88d): https://github.com/svknoe/40k-WTC-Draft-Solver/actions/runs/28684039946 conclusion: `success` (both steps passed, ~51s total)  **RED** — scratch branch `m1/ci-red-check` (off `m1/ci`, since deleted, never opened as a PR) with a deliberate one-cell change to `drafter/resources/matches/Six/pairing_matrix.csv` (Anna vs Grok: `3` → `99`), which breaks `test_six_player_top_level_value`'s pinned golden value: https://github.com/svknoe/40k-WTC-Draft-Solver/actions/runs/28684089996 conclusion: `failure` (the "Fast golden tests" step failed as expected; smoke test still passed since it uses the Smoke fixture, not Six). Scratch branch deleted locally and on `origin` after recording this run; the breakage was never merged anywhere.  ## Test plan  - [x] Local: `printf '\n\n\n\n\n\nn\n' | python scripts/smoke_draft.py` passes - [x] Local: `python -m pytest` passes (3 passed, 1 deselected, ~17s) - [x] CI green on `m1/ci` push (see above) - [x] CI red on deliberately broken scratch branch (see above), scratch branch cleaned up - [x] CI green on this PR's `pull_request`-triggered run: f49f88d https://github.com/svknoe/40k-WTC-Draft-Solver/actions/runs/28684138443 and, after review follow-up 5f784b4, https://github.com/svknoe/40k-WTC-Draft-Solver/actions/runs/28684365786 (both `success`)  🤖 Generated with [Claude Code](https://claude.com/claude-code)