### PR TITLE
test+ci: follow-ups from M1 review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,10 @@
 name: CI
 
+# push is limited to main so PR-branch pushes don't trigger a duplicate run
+# alongside the pull_request event.
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:

--- a/drafter/tests/test_golden_values.py
+++ b/drafter/tests/test_golden_values.py
@@ -94,16 +94,18 @@ def test_six_player_top_level_value():
 # repo's dev box, matching the ~5 min / 275s PLAN.md baseline) and hard-coded
 # here; see the PR report for the raw run output.
 #
-# Only the value is pinned exactly. The top-level strategy support set (which
-# players get non-negligible probability) is asserted too, since it is stable
-# across runs at this precision, but the exact probabilities are not asserted
-# here -- support enumeration over an 8-player top-level game can return
-# different (but equally valid) equilibria/orderings depending on nashpy's
-# internal enumeration order, while the *value* of a zero-sum game's
-# equilibria is unique and stable.
+# Only the value is pinned exactly. The top-level strategy *support sets*
+# (which players get non-negligible probability) are pinned as sets, but the
+# exact probabilities are not -- support enumeration over an 8-player
+# top-level game can return different (but equally valid) equilibria/orderings
+# depending on nashpy's internal enumeration order, while the *value* of a
+# zero-sum game's equilibria is unique and stable. The support sets below have
+# been identical across independent fresh solves (2026-07 baseline runs).
 
 SCOTLAND_K = 3
 SCOTLAND_EXPECTED_VALUE = 6.189614531232928
+SCOTLAND_EXPECTED_FRIENDLY_SUPPORT = frozenset({"Mariusz", "Petter"})
+SCOTLAND_EXPECTED_ENEMY_SUPPORT = frozenset({"AdMech", "Drukhari"})
 
 
 @pytest.mark.slow
@@ -111,5 +113,5 @@ def test_scotland_8_player_k3():
     result = solve_fixture("Scotland", SCOTLAND_K, timeout=900)
     assert result["n"] == 8
     assert result["value"] == pytest.approx(SCOTLAND_EXPECTED_VALUE, abs=1e-6)
-    assert len(support_set(result["friendly"])) >= 1
-    assert len(support_set(result["enemy"])) >= 1
+    assert support_set(result["friendly"]) == SCOTLAND_EXPECTED_FRIENDLY_SUPPORT
+    assert support_set(result["enemy"]) == SCOTLAND_EXPECTED_ENEMY_SUPPORT


### PR DESCRIPTION
Two small findings from the M1 review:

1. **Pin the Scotland support sets.** The slow test's comment claimed the top-level support sets were asserted for stability, but the assertion was `len(...) >= 1`, which any strategy satisfies. Now pinned exactly: friendly {Mariusz, Petter}, enemy {AdMech, Drukhari}. Verified against a fresh 4:32 solve (272 s, matching the PLAN.md baseline) on top of the two earlier baseline runs that produced identical supports.
2. **Deduplicate CI runs.** `push` is now limited to `main`, so PR-branch pushes trigger only the `pull_request` job instead of two identical runs.

Fast suite: 3 passed. Slow suite: 1 passed (272 s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)