### PR TITLE
discard_attacker: return refused attackers to the child pools

### DIFF
--- a/drafter/data/read_write.py
+++ b/drafter/data/read_write.py
@@ -4,11 +4,12 @@ import json  # standard libraries
 # Caches carry solved game values, so any change to the value model makes old
 # caches silently wrong (they would load fine and give plausible numbers).
 # Bump this whenever cached values are no longer comparable with the current
-# engine. Version 3 = numeric ratings on the deviation scale, internal =
-# score - 10 (issue #30); version 2 = the 11th-edition best/worst map model
-# (issue #9) with the mistaken 2*(score-10) conversion; version 1 (implicit --
-# no marker file existed) = the old map-importance model.
-CACHE_FORMAT_VERSION = 3
+# engine. Version 4 = discard_attacker returns the refused attackers to the
+# child pools (issue #32); version 3 = numeric ratings on the deviation scale,
+# internal = score - 10 (issue #30); version 2 = the 11th-edition best/worst
+# map model (issue #9) with the mistaken 2*(score-10) conversion; version 1
+# (implicit -- no marker file existed) = the old map-importance model.
+CACHE_FORMAT_VERSION = 4
 CACHE_FORMAT_FILENAME = "cache_format.json"
 
 

--- a/drafter/solver/games.py
+++ b/drafter/solver/games.py
@@ -112,9 +112,13 @@ def discard_attacker(n, selected_attackers_gamestate, select_defender_strategies
     fA_eD = utilities.get_pairing_value(f_attacker_A, e_defender, e_defender)
     fB_eD = utilities.get_pairing_value(f_attacker_B, e_defender, e_defender)
 
+    # The child gamestate receives the REFUSED attackers back into the pools
+    # (issue #32): in AB, e_B plays the friendly defender and f_A plays the
+    # enemy defender, so the refused pair returning to the pools is (f_B, e_A)
+    # -- and mirrored in BA. The kept attackers' games are the fD_*/f*_eD terms.
     AA = fD_eB + fB_eD + select_defender_strategies[get_game_key(f_attacker_A, e_attacker_A)][2]
-    AB = fD_eB + fA_eD + select_defender_strategies[get_game_key(f_attacker_A, e_attacker_B)][2]
-    BA = fD_eA + fB_eD + select_defender_strategies[get_game_key(f_attacker_B, e_attacker_A)][2]
+    AB = fD_eB + fA_eD + select_defender_strategies[get_game_key(f_attacker_B, e_attacker_A)][2]
+    BA = fD_eA + fB_eD + select_defender_strategies[get_game_key(f_attacker_A, e_attacker_B)][2]
     BB = fD_eA + fA_eD + select_defender_strategies[get_game_key(f_attacker_B, e_attacker_B)][2]
 
     game_array = np.array([[AA, AB], [BA, BB]])

--- a/drafter/tests/test_discard_wiring.py
+++ b/drafter/tests/test_discard_wiring.py
@@ -1,0 +1,86 @@
+"""Regression test for the discard_attacker child-key wiring (issue #32).
+
+The n=6/8 discard game's off-diagonal entries must return the REFUSED
+attackers to the child pools, not the attackers who just played. The golden
+tests would catch a regression only as an unexplained value shift; this test
+pins the wiring itself, cell by cell, with sentinel child values.
+
+In-process like test_map_model.py: match_info is monkeypatched and
+get_game_strategy is stubbed to capture the payoff matrix, so no solver or
+global state is involved.
+"""
+import pytest
+
+import drafter.common.utilities as utilities
+import drafter.data.match_info as match_info
+import drafter.solver.games as games
+from drafter.common.draft_stage import DraftStage
+from drafter.common.game_state import GameState
+from drafter.common.team_permutation import TeamPermutation
+
+
+def child_key(remaining_friends, extra_friend, remaining_enemies, extra_enemy):
+    return GameState(
+        DraftStage.none,
+        TeamPermutation(remaining_friends + [extra_friend]),
+        TeamPermutation(remaining_enemies + [extra_enemy]),
+    ).get_key()
+
+
+def test_discard_attacker_returns_refused_attackers_to_child_pools(monkeypatch):
+    # 6-player state, mid-draft: defenders picked, attackers presented.
+    # Names chosen already-sorted so TeamPermutation's attacker sorting is a
+    # no-op and fA/eA keep their roles.
+    f_defender, f_attacker_A, f_attacker_B = "Fdef", "FattA", "FattB"
+    remaining_friends = ["Frem1", "Frem2", "Frem3"]
+    e_defender, e_attacker_A, e_attacker_B = "Edef", "EattA", "EattB"
+    remaining_enemies = ["Erem1", "Erem2", "Erem3"]
+
+    # Distinct pairing values so each fixed-pairing term is identifiable:
+    # the friendly defender defends (best map), the enemy defender forces the
+    # worst map. get_pairing_value reads both dictionaries for every pairing,
+    # so the side not selected is filled with a sentinel that would blow up
+    # the expected matrix if it ever leaked in.
+    monkeypatch.setattr(match_info, "pairing_dictionary_best", {
+        f_defender: {e_attacker_A: 1.0, e_attacker_B: 2.0},
+        f_attacker_A: {e_defender: -99.0}, f_attacker_B: {e_defender: -99.0}})
+    monkeypatch.setattr(match_info, "pairing_dictionary_worst", {
+        f_defender: {e_attacker_A: -99.0, e_attacker_B: -99.0},
+        f_attacker_A: {e_defender: 10.0}, f_attacker_B: {e_defender: 20.0}})
+
+    # Sentinel child-game values, one per (returned friend, returned enemy).
+    sentinels = {
+        child_key(remaining_friends, f_attacker_A, remaining_enemies, e_attacker_A): 1000.0,
+        child_key(remaining_friends, f_attacker_B, remaining_enemies, e_attacker_A): 2000.0,
+        child_key(remaining_friends, f_attacker_A, remaining_enemies, e_attacker_B): 3000.0,
+        child_key(remaining_friends, f_attacker_B, remaining_enemies, e_attacker_B): 4000.0,
+    }
+    select_defender_strategies = {key: [None, None, value] for key, value in sentinels.items()}
+
+    captured = {}
+
+    def capture_game_strategy(cache, game_array, friendly_options, enemy_options):
+        captured["array"] = game_array
+        return "stub"
+
+    monkeypatch.setattr(utilities, "get_game_strategy", capture_game_strategy)
+
+    gamestate = GameState(
+        DraftStage.select_attackers,
+        TeamPermutation(remaining_friends, f_defender, f_attacker_A, f_attacker_B),
+        TeamPermutation(remaining_enemies, e_defender, e_attacker_A, e_attacker_B),
+    )
+
+    assert games.discard_attacker(6, gamestate, select_defender_strategies) == "stub"
+
+    # Row = enemy attacker the friendly side refuses, column = friendly
+    # attacker the enemy side refuses. In each cell the KEPT attackers play
+    # the defenders and the REFUSED pair is returned to the child pools.
+    fD_eA, fD_eB = 1.0, 2.0
+    fA_eD, fB_eD = 10.0, 20.0
+    expected = [
+        # refuse eA / they refuse fA: eB plays fD, fB plays eD, child gets (fA, eA)
+        [fD_eB + fB_eD + 1000.0, fD_eB + fA_eD + 2000.0],
+        [fD_eA + fB_eD + 3000.0, fD_eA + fA_eD + 4000.0],
+    ]
+    assert captured["array"].tolist() == expected

--- a/drafter/tests/test_golden_values.py
+++ b/drafter/tests/test_golden_values.py
@@ -52,6 +52,10 @@ from drafter.tests.conftest import solve_fixture, strategy_probabilities, suppor
 # 10 + (pairing +/- importance)/2) doubles the file notation; no Smoke cell
 # clamps, so the internal values -- and this pin -- are bit-identical.
 # Re-verified: 3x bit-identical fresh solves + the independent brute force.
+#
+# discard_attacker child-key fix (issue #32): UNCHANGED again, provably --
+# the bug lived in the n=6/8 recursion; a 4-player draft only uses the
+# closed-form endgame. Re-verified 3x bit-identical.
 
 SMOKE_K = 4
 SMOKE_EXPECTED_VALUE = 4.997553182223153
@@ -87,13 +91,17 @@ def test_smoke_4_player_top_level_strategies():
 # repo's Ryzen 9800X3D-class dev box, cold Python start included): ~12s.
 # Comfortably under the ~30s CI-friendly target from the issue.
 #
-# Value re-pinned for the best/worst map model (issue #9): 3 bit-identical
-# fresh solves via scripts/compute_golden_value.py Six 4. Unchanged by the
-# deviation-scale correction (issue #30) -- parse halving and notation
-# doubling cancel exactly, no Six cell clamps (re-verified 3x).
+# Value re-pinned for the discard_attacker child-key fix (issue #32): 3
+# bit-identical fresh solves via scripts/compute_golden_value.py Six 4, and
+# cross-checked against the independent scripts/brute_force_oracle.py
+# (explicit recursion + scipy linprog): oracle 1.9058104884743514 on the
+# unrestricted tree, fixed engine 1.9058104884743512 unrestricted AND at k=4
+# (the k-heuristic does not bind on this fixture) -- 1 ulp agreement, same
+# top-level mix (Cleo 0.103 / Elin 0.897). Previous pins: 1.5140341559225499
+# (issues #9/#30, encoding the pre-#32 child-key bug).
 
 SIX_K = 4
-SIX_EXPECTED_VALUE = 1.5140341559225499
+SIX_EXPECTED_VALUE = 1.9058104884743512
 
 
 def test_six_player_top_level_value():
@@ -107,13 +115,13 @@ def test_six_player_top_level_value():
 # by default (see pytest.ini's `addopts = -m "not slow"`). Run explicitly:
 #     .venv\\Scripts\\python.exe -m pytest -m slow
 #
-# The full-precision value was re-pinned for the best/worst map model
-# (issue #9) via two bit-identical fresh solves of
+# The full-precision value was re-pinned for the discard_attacker child-key
+# fix (issue #32) via two bit-identical fresh solves of
 # scripts/compute_golden_value.py Scotland 3 (~4.5 min each on this repo's
-# dev box); see the issue #9 PR for the raw run output. Unchanged by the
-# deviation-scale correction (issue #30): parse halving and notation doubling
-# cancel, and the one clamped cell (Bjorn vs Sisters worst map, -13 -> -10)
-# never reaches the k=3 equilibrium path (re-verified 2x bit-identical).
+# dev box); see the issue #32 PR for the raw run output. The fix moved the
+# value from 6.348743764113647 (pinned in #9, unchanged by #30) and flipped
+# the friendly defender equilibrium from pure Petter to pure Mariusz -- the
+# bug had double-counted kept attackers, inflating continuations.
 #
 # Only the value is pinned exactly. The top-level strategy *support sets*
 # (which players get non-negligible probability) are pinned as sets, but the
@@ -121,12 +129,12 @@ def test_six_player_top_level_value():
 # top-level game can return different (but equally valid) equilibria/orderings
 # depending on nashpy's internal enumeration order, while the *value* of a
 # zero-sum game's equilibria is unique and stable. The support sets below have
-# been identical across independent fresh solves (2026-07, post-#9 re-pin:
-# both top-level strategies are pure under the new model).
+# been identical across independent fresh solves (2026-07, post-#32 re-pin:
+# both top-level strategies are pure).
 
 SCOTLAND_K = 3
-SCOTLAND_EXPECTED_VALUE = 6.348743764113647
-SCOTLAND_EXPECTED_FRIENDLY_SUPPORT = frozenset({"Petter"})
+SCOTLAND_EXPECTED_VALUE = 5.875946490218083
+SCOTLAND_EXPECTED_FRIENDLY_SUPPORT = frozenset({"Mariusz"})
 SCOTLAND_EXPECTED_ENEMY_SUPPORT = frozenset({"Drukhari"})
 
 

--- a/scripts/brute_force_oracle.py
+++ b/scripts/brute_force_oracle.py
@@ -59,6 +59,7 @@ def read_matrix(name):
 
 FRIENDS, ENEMIES, BEST = read_matrix("pairing_matrix_best.csv")
 _, _, WORST = read_matrix("pairing_matrix_worst.csv")
+assert all(BEST[pair] >= WORST[pair] for pair in BEST),     "best < worst somewhere in {} -- swapped files?".format(FOLDER)
 
 
 def value(friend, enemy, defender=None):
@@ -174,4 +175,5 @@ def main():
     print("Top-level game value (repr): {!r}".format(v))
 
 
-main()
+if __name__ == "__main__":
+    main()

--- a/scripts/brute_force_oracle.py
+++ b/scripts/brute_force_oracle.py
@@ -1,0 +1,177 @@
+"""Independent brute-force oracle for 4- and 6-player match folders.
+
+Shares NO solver code with the drafter package: reads the two CSVs directly,
+enumerates the draft explicitly, and solves every zero-sum stage game with
+scipy's linear-programming solver (drafter uses nashpy enumeration instead).
+Used to cross-check golden values whenever the value model or the solver
+changes (issues #9, #30, #32).
+
+Model (11th edition, PLAN.md workstream C):
+  - defender picks the map: friendly defender -> best-map value, enemy
+    defender -> worst-map value, no defender -> midpoint of best and worst
+    (settings.neutral_map_weight default 0.5 is hard-coded here)
+  - ratings normalised as internal = score - 10 (deviation scale), tokens
+    --/-/0/+/++ = -8/-4/0/+4/+8
+  - draft: both teams simultaneously pick a defender, then two attackers
+    from their remainder against the enemy defender, then each refuses one
+    of the two attackers presented; the kept attacker plays the defender and
+    the REFUSED attackers return to the pools for the next round (the child
+    wiring issue #32 fixed in the engine). At 4 players the endgame is
+    closed: refused vs refused and last vs last play each other.
+
+The oracle is exhaustive (no k-restriction), so compare it against the
+engine with settings.restrict_attackers = False. 8-player folders are
+rejected: the unrestricted 8-player tree costs hours here; the 6-player
+oracle already exercises every code path the 4-player one cannot (in
+particular the recursive discard-stage child wiring).
+
+Usage:
+    python scripts/brute_force_oracle.py [<folder>]     # default Smoke
+
+Prints the top-level game value and one optimal friendly defender mix.
+"""
+import csv
+import itertools
+import sys
+from pathlib import Path
+
+import numpy as np
+from scipy.optimize import linprog
+
+FOLDER = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(
+    "drafter/resources/matches/Smoke")
+
+TOKENS = {'--': -8.0, '-': -4.0, '0': 0.0, '+': 4.0, '++': 8.0}
+NEUTRAL_MAP_WEIGHT = 0.5
+
+
+def read_matrix(name):
+    with (FOLDER / name).open(encoding="utf-8-sig") as f:
+        rows = [row for row in csv.reader(f) if row]
+    friends, enemies = rows[0], rows[1]
+    values = {}
+    for friend, row in zip(friends, rows[2:]):
+        for enemy, cell in zip(enemies, row):
+            cell = cell.strip()
+            values[(friend, enemy)] = TOKENS[cell] if cell in TOKENS else float(cell) - 10
+    return friends, enemies, values
+
+
+FRIENDS, ENEMIES, BEST = read_matrix("pairing_matrix_best.csv")
+_, _, WORST = read_matrix("pairing_matrix_worst.csv")
+
+
+def value(friend, enemy, defender=None):
+    if defender == friend:
+        return BEST[(friend, enemy)]
+    if defender == enemy:
+        return WORST[(friend, enemy)]
+    assert defender is None
+    best, worst = BEST[(friend, enemy)], WORST[(friend, enemy)]
+    return worst + NEUTRAL_MAP_WEIGHT * (best - worst)
+
+
+def solve_zero_sum(matrix):
+    """Value + row strategy of the zero-sum game (row maximises), by LP."""
+    a = np.asarray(matrix, dtype=float)
+    shift = a.min()
+    a = a - shift + 1  # make strictly positive so the standard LP trick works
+    rows, cols = a.shape
+    # min sum(x) s.t. A^T x >= 1, x >= 0 ; game value = 1/sum(x)
+    res = linprog(c=np.ones(rows), A_ub=-a.T, b_ub=-np.ones(cols),
+                  bounds=[(0, None)] * rows, method="highs")
+    assert res.success, res.message
+    v = 1 / res.x.sum()
+    return v + shift - 1, res.x * v
+
+
+def endgame_discard_value(f_def, f_att, e_def, e_att, f_last, e_last):
+    """4-player discard: closed endgame. Rows = which enemy attacker the
+    friendly side refuses, columns = which friendly attacker the enemy side
+    refuses; refused vs refused and last vs last play each other."""
+    fixed = value(f_last, e_last)
+    m = np.zeros((2, 2))
+    for i, e_refused in enumerate(e_att):
+        e_kept = e_att[1 - i]
+        for j, f_refused in enumerate(f_att):
+            f_kept = f_att[1 - j]
+            m[i, j] = (value(f_def, e_kept, defender=f_def)
+                       + value(f_kept, e_def, defender=e_def)
+                       + value(f_refused, e_refused)
+                       + fixed)
+    v, _ = solve_zero_sum(m)
+    return v
+
+
+def recursive_discard_value(f_def, f_att, f_rem, e_def, e_att, e_rem):
+    """6-player discard: the two fixed pairings plus the value of the next
+    round, where the REFUSED attackers rejoin the remaining players."""
+    m = np.zeros((2, 2))
+    for i, e_refused in enumerate(e_att):
+        e_kept = e_att[1 - i]
+        for j, f_refused in enumerate(f_att):
+            f_kept = f_att[1 - j]
+            m[i, j] = (value(f_def, e_kept, defender=f_def)
+                       + value(f_kept, e_def, defender=e_def)
+                       + none_stage_value(tuple(sorted(f_rem + [f_refused])),
+                                          tuple(sorted(e_rem + [e_refused]))))
+    v, _ = solve_zero_sum(m)
+    return v
+
+
+def attackers_stage_value(f_def, f_rest, e_def, e_rest):
+    f_options = list(itertools.combinations(f_rest, 2))
+    e_options = list(itertools.combinations(e_rest, 2))
+    m = np.zeros((len(f_options), len(e_options)))
+    for i, f_att in enumerate(f_options):
+        f_rem = [p for p in f_rest if p not in f_att]
+        for j, e_att in enumerate(e_options):
+            e_rem = [p for p in e_rest if p not in e_att]
+            if len(f_rest) == 3:
+                m[i, j] = endgame_discard_value(
+                    f_def, list(f_att), e_def, list(e_att), f_rem[0], e_rem[0])
+            else:
+                m[i, j] = recursive_discard_value(
+                    f_def, list(f_att), f_rem, e_def, list(e_att), e_rem)
+    v, _ = solve_zero_sum(m)
+    return v
+
+
+_none_stage_cache = {}
+
+
+def none_stage_value(f_players, e_players):
+    """Value of a fresh n-player round (both defenders still to pick),
+    memoised on the two player sets."""
+    key = (f_players, e_players)
+    if key not in _none_stage_cache:
+        m, _, _ = defender_stage_matrix(f_players, e_players)
+        _none_stage_cache[key], _ = solve_zero_sum(m)
+    return _none_stage_cache[key]
+
+
+def defender_stage_matrix(f_players, e_players):
+    m = np.zeros((len(f_players), len(e_players)))
+    for i, f_def in enumerate(f_players):
+        f_rest = [p for p in f_players if p != f_def]
+        for j, e_def in enumerate(e_players):
+            e_rest = [p for p in e_players if p != e_def]
+            m[i, j] = attackers_stage_value(f_def, f_rest, e_def, e_rest)
+    return m, f_players, e_players
+
+
+def main():
+    if len(FRIENDS) not in (4, 6):
+        sys.exit("Oracle supports 4- and 6-player folders; {} has {} players "
+                 "(an unrestricted 8-player tree is impractical here).".format(FOLDER, len(FRIENDS)))
+
+    m, _, _ = defender_stage_matrix(tuple(FRIENDS), tuple(ENEMIES))
+    v, strategy = solve_zero_sum(m)
+
+    print("Folder: {} ({} players, unrestricted)".format(FOLDER, len(FRIENDS)))
+    print("Friendly defender strategy (one optimum):",
+          {f: round(p, 3) for f, p in zip(FRIENDS, strategy)})
+    print("Top-level game value (repr): {!r}".format(v))
+
+
+main()


### PR DESCRIPTION
Fixes the pre-existing discard-stage bug found in the PR #27 review: the 6/8-player `discard_attacker` wired the *kept* attackers into the child gamestate pools instead of the *refused* ones, double-counting the players who just played and never letting the refused pair play again. Closes #32. M3's first PR, landing before B1 (#12) so the LP rewrite verifies against rules-correct values.

## The fix

Two child keys swap in `games.py::discard_attacker` (n=6/8 path): `AB` now returns `(f_attacker_B, e_attacker_A)` to the pools, `BA` the mirror. The diagonal entries and the 4-player closed form were always correct. A comment now states the invariant. `CACHE_FORMAT_VERSION` → 4: every existing cache baked the bug in and is silently invalidated by the marker logic.

## Verification

**Committed oracle.** `scripts/brute_force_oracle.py` — an independent implementation (explicit 4/6-player draft recursion with memoised subgames, zero-sum games via `scipy.optimize.linprog`, no drafter solver code) grown from the #27/#30 verification scripts. 8-player folders are rejected as impractical; the 6-player tree exercises the recursive discard wiring that a 4-player oracle cannot see (which is why #27's Smoke-only check missed this bug).

| Check | Oracle | Fixed engine |
|---|---|---|
| Six, unrestricted | `1.9058104884743514` | `1.9058104884743512` (1 ulp, same mix Cleo 0.103 / Elin 0.897) |
| Smoke (4-player, fix can't apply) | `4.997553182223154` | `4.997553182223153` (existing pin, 1 ulp) |

The oracle's unrestricted-Six value also reproduces the #27 reviewer's rules-correct number (`1.9058104884743514`) to the digit, from a fully separate implementation.

**Wiring regression test.** New `drafter/tests/test_discard_wiring.py` pins the child-key wiring itself: sentinel child values per (returned friend, returned enemy) pair, payoff matrix captured via a stubbed `get_game_strategy`, every cell asserted. A re-swap would fail this test directly rather than surfacing as an unexplained golden shift.

## Golden re-pins (deliberate — this is the point of the fix)

| Fixture | Old pin (encoded the bug) | New pin | Provenance |
|---|---|---|---|
| Smoke k=4 | `4.997553182223153` | **unchanged** (provably: 4-player) | 3× bit-identical |
| Six k=4 | `1.5140341559225499` | `1.9058104884743512` | 3× bit-identical + oracle to 1 ulp; equals the unrestricted value (the k-heuristic doesn't bind on this fixture) |
| Scotland k=3 | `6.348743764113647` | `5.875946490218083` | 2× bit-identical fresh solves + `pytest -m slow` (a third) |

**The Scotland equilibrium changed, not just the value**: the friendly defender flips from pure Petter to pure **Mariusz** (enemy stays pure Drukhari), and the value drops by ~0.47 — the bug's double-counted kept attackers were inflating continuations enough to recommend the wrong defender on a real matrix.

Fast suite: 52 passed. Smoke draft complete. `pytest -m slow`: 1 passed, 235s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
