### PR TITLE
B1: solve zero-sum games directly (closed form + LP)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ drafter/
     team_permutation.py    one team's partial draft state; enumeration of successor states;
                            the k-restriction heuristic (restrict to k best attackers)
     game_state.py          GameState = (draft_stage, friendly TeamPermutation, enemy TeamPermutation)
-    utilities.py           nashpy game solving, pairing-value lookup, key/dictionary naming
+    utilities.py           direct zero-sum game solving (2x2 closed form + LP), pairing-value lookup, key/dictionary naming
   data/
     settings.py            all knobs (team name, k-restriction, read/write caches)
     match_info.py          module-level globals: enemy team name + input matrices
@@ -61,9 +61,15 @@ drafter/
 2. **Strategy solving** (`strategy_dictionaries`): iterate stages deepest
    first (4-player select_attackers up to 8-player none). For each gamestate
    build the payoff matrix whose entries are the already-solved values of
-   child states (`games.py`), then solve that matrix game with **nashpy**
-   (support enumeration → vertex enumeration → Lemke-Howson fallbacks, cached
-   by matrix hash). The 4-player discard endgame is closed-form.
+   child states (`games.py`), then solve that matrix game **directly as the
+   zero-sum game it is** (`utilities.get_game_solution`, PLAN.md B1): a pure
+   saddle point when one exists, otherwise a 2x2 closed form, otherwise one
+   `scipy.optimize.linprog` (HiGHS) call whose dual yields the opposing
+   strategy. Deterministic, no degenerate-game warnings. Solutions are cached
+   by matrix hash — both bit-identical (per-stage caches in `games.py`) and
+   translation-normalised (`utilities.normalised_game_solution_cache`, since
+   zero-sum strategies/value are invariant under adding a constant). The
+   4-player discard endgame is closed-form.
 3. **Draft loop** (`draft.py`): walks the solved tree interactively. If the
    user makes a move outside the enumerated tree (possible with k-restriction),
    the tree is extended and re-solved on the fly.
@@ -76,12 +82,16 @@ and last-players games).
 
 **Known scale/pain points** (measured 2026-07, Ryzen 9800X3D, k as noted):
 
-- Fresh 8-player solve is the "one hour, 16 GB RAM" problem the user reports
-  (historical, k=4). The cost is dominated by the ~10^5–10^6 4-player-stage
-  gamestates, each solved by nashpy support enumeration; the discrete rating
-  scale makes most games degenerate, triggering slow fallbacks.
-- All games here are **zero-sum**, so each could be solved by one small LP
-  instead of enumeration — the main known speed lever (see PLAN.md).
+- Fresh 8-player solve was historically the "one hour, 16 GB RAM" problem
+  (k=4). The cost is dominated by the ~10^5–10^6 4-player-stage gamestates.
+- **B1 (done, issue #12):** every game is zero-sum, now solved directly
+  (saddle / 2x2 closed form / one HiGHS LP) instead of by nashpy's
+  general-bimatrix support enumeration and its degenerate-game fallback chain.
+  This cut the Scotland k=3 strategy phase from ~275 s to ~29 s (≈9×) with
+  bit-stable golden values and no warnings. The remaining strategy-phase cost
+  is now split between the ~35k genuinely-mixed LP solves (scipy's per-call
+  wrapper overhead dominates for these tiny games) and the string-keyed
+  gamestate iteration — the latter is what B2 (integer state encoding) targets.
 - Cached JSON for one 8-player opponent ≈ 630 MB (strategy dicts dominate);
   loading that cache takes ~19 s. String keys are a large share of the RAM.
 - `restricted_attackers_count` (k) in settings.py is the only current knob:
@@ -154,8 +164,10 @@ Notes for agents:
   same explicit call.
 - Settings are plain module globals in `drafter/data/settings.py`; there are
   no CLI flags. Monkeypatch settings before `initialise()` in scripts.
-- nashpy prints "degenerate game" RuntimeWarnings during solving — harmless,
-  the code falls back to other algorithms.
+- The zero-sum solver is deterministic and silent: no RuntimeWarnings during
+  solving (nashpy's "degenerate game" warnings are gone with nashpy, issue
+  #12). scipy's `linprog` is a required dependency; nashpy and networkx are
+  no longer dependencies.
 
 ## Conventions & state
 

--- a/drafter/common/utilities.py
+++ b/drafter/common/utilities.py
@@ -1,7 +1,8 @@
 from pathlib import Path  # standard libraries
 from enum import Enum
 
-import nashpy  # 3rd party packages
+import numpy as np  # 3rd party packages
+from scipy.optimize import linprog
 
 import drafter.data.match_info as match_info  # local source
 import drafter.data.settings as settings
@@ -22,65 +23,175 @@ def get_transposed_pairing_dictionary(pairing_dictionary):
     return transposed_pairing_dictionary
 
 
-def get_game_solution(game):
-    support_value = get_game_overview_from_equilibria(game, game.support_enumeration())
-    if support_value is not None:
-        return support_value
+# Every game in the draft tree is zero-sum: the row (friendly) player maximises
+# `game_array`, the column (enemy) player minimises it. Solve it directly rather
+# than by nashpy's general-bimatrix support enumeration (issue #12 / PLAN.md B1):
+# a pure saddle point when one exists, else a 2x2 closed form, else one small LP.
+# All paths are deterministic and never emit nashpy's "degenerate game" warnings.
+# Returns [row_strategy, column_strategy, value]; the value of a zero-sum game is
+# unique even when multiple equilibrium strategies exist.
+def get_game_solution(game_array):
+    a = np.asarray(game_array, dtype=float)
 
-    vertex_value = get_game_overview_from_equilibria(game, game.vertex_enumeration())
-    if vertex_value is not None:
-        return vertex_value
+    if a.shape == (2, 2):
+        return solve_2x2_zero_sum_game(a)
 
-    lemke_howson_value = get_game_overview_from_equilibria(game, game.lemke_howson_enumeration())
-    if lemke_howson_value is not None:
-        return lemke_howson_value
+    return solve_larger_zero_sum_game(a)
 
-    return None
+
+# Closed form for the 2x2 zero-sum game (the ~90% common case in the tree). A
+# 2x2 zero-sum game is either fully mixed or has a pure saddle point. The mixed
+# formula is tried first; if it yields a probability outside [0, 1] (or the
+# denominator is zero) no interior equilibrium exists, so a saddle point does.
+# `.tolist()` pulls the four entries out as Python floats in one call: the whole
+# closed form is then plain-float arithmetic, far cheaper than repeated numpy
+# scalar indexing over the ~200k distinct 2x2 games on the Scotland k=3 tree.
+def solve_2x2_zero_sum_game(a):
+    (a11, a12), (a21, a22) = a.tolist()
+
+    denominator = a11 + a22 - a12 - a21
+
+    if denominator != 0.0:
+        row_probability = (a22 - a21) / denominator
+        column_probability = (a22 - a12) / denominator
+
+        if 0.0 <= row_probability <= 1.0 and 0.0 <= column_probability <= 1.0:
+            value = (a11 * a22 - a12 * a21) / denominator
+            return [[row_probability, 1.0 - row_probability],
+                    [column_probability, 1.0 - column_probability],
+                    value]
+
+    return solve_2x2_saddle_point(a11, a12, a21, a22)
+
+
+# No interior mixed equilibrium => a pure saddle point exists. The row
+# (maximising) player plays the row with the largest row-minimum; the column
+# (minimising) player plays the column with the smallest column-maximum. For a
+# 2x2 zero-sum game these coincide at the saddle, whose entry is the value.
+def solve_2x2_saddle_point(a11, a12, a21, a22):
+    row_minima = [min(a11, a12), min(a21, a22)]
+    best_row = 0 if row_minima[0] >= row_minima[1] else 1
+
+    column_maxima = [max(a11, a21), max(a12, a22)]
+    best_column = 0 if column_maxima[0] <= column_maxima[1] else 1
+
+    row_strategy = [0.0, 0.0]
+    row_strategy[best_row] = 1.0
+
+    column_strategy = [0.0, 0.0]
+    column_strategy[best_column] = 1.0
+
+    value = [[a11, a12], [a21, a22]][best_row][best_column]
+
+    return [row_strategy, column_strategy, value]
+
+
+# Larger games: try a pure saddle point first, else one LP. The discrete rating
+# scale leaves many games with a pure equilibrium -- on the Scotland k=3 tree
+# ~half of the non-2x2 games do -- and detecting one costs two array reductions,
+# far cheaper than an LP. A pure saddle exists iff the maximin (best row-minimum)
+# equals the minimax (best column-maximum); that entry is then the game value.
+def solve_larger_zero_sum_game(a):
+    row_minima = a.min(axis=1)
+    column_maxima = a.max(axis=0)
+
+    best_row = int(row_minima.argmax())
+    best_column = int(column_maxima.argmin())
+
+    if row_minima[best_row] == column_maxima[best_column]:
+        row_strategy = [0.0] * a.shape[0]
+        row_strategy[best_row] = 1.0
+        column_strategy = [0.0] * a.shape[1]
+        column_strategy[best_column] = 1.0
+        return [row_strategy, column_strategy, float(a[best_row, best_column])]
+
+    return solve_zero_sum_game_by_linear_program(a)
+
+
+# Solved games keyed by their translation-normalised (positivity-shifted) matrix.
+# A zero-sum game's optimal strategies and its value are translation-invariant --
+# adding a constant to every payoff shifts only the value -- so matrices that
+# differ only by a constant, common on the discrete rating scale, share one LP
+# solve. Cache the shifted matrix's solution (strategies + shifted value); each
+# caller adds back its own shift. Complements the per-stage matrix-hash caches in
+# games.py, which catch bit-identical (un-shifted) matrices.
+normalised_game_solution_cache = {}
+
+
+# The mixed larger game, by one linear program (scipy's HiGHS). Shift the payoff
+# matrix to be strictly positive so the classic LP reformulation applies: the row
+# maximiser solves  min 1.x  s.t.  A^T x >= 1, x >= 0, with game value = 1/sum x
+# and row strategy = x * value. The column (minimising) player's strategy is the
+# dual of that same LP -- scipy exposes it as the inequality-constraint marginals
+# -- so one solve yields both sides; no need for the symmetric second LP. The
+# shift is undone on the value. This is the formulation the independent oracle
+# (scripts/brute_force_oracle.py) uses to cross-check golden values. Only the
+# value propagates up the tree (games.get_game_array); the strategies are read
+# solely by the interactive draft loop.
+def solve_zero_sum_game_by_linear_program(a):
+    shift = a.min()
+    positive_a = a - shift + 1.0
+
+    cache_key = hash(positive_a.tobytes())
+    solution = normalised_game_solution_cache.get(cache_key)
+    if solution is None:
+        solution = solve_positivity_shifted_matrix_game(positive_a)
+        normalised_game_solution_cache[cache_key] = solution
+
+    row_strategy, column_strategy, shifted_value = solution
+
+    return [row_strategy, column_strategy, shifted_value + shift - 1.0]
+
+
+def solve_positivity_shifted_matrix_game(positive_a):
+    row_count, column_count = positive_a.shape
+
+    result = linprog(
+        c=np.ones(row_count),
+        A_ub=-positive_a.T,
+        b_ub=-np.ones(column_count),
+        bounds=(0, None),
+        method="highs")
+
+    if not result.success:
+        raise RuntimeError("Zero-sum LP failed: {}".format(result.message))
+
+    shifted_value = 1.0 / result.x.sum()
+    row_strategy = list(result.x * shifted_value)
+
+    # Dual solution: |marginals| of the column constraints is the column
+    # player's optimal (unnormalised) mix; scaling by the value normalises it.
+    column_strategy = list(np.abs(result.ineqlin.marginals) * shifted_value)
+
+    return [row_strategy, column_strategy, shifted_value]
 
 
 def get_game_strategy(game_solution_cache, game_array, friendly_team_options, enemy_team_options):
     game_array_hash = hash(game_array.tostring())
 
     if game_array_hash in game_solution_cache:
-        game_solution = game_solution_cache[game_array_hash]
+        row_probabilities, column_probabilities, value = game_solution_cache[game_array_hash]
     else:
-        game = nashpy.Game(game_array)
-        game_solution = get_game_solution(game)
-        game_solution_cache[game_array_hash] = game_solution
+        row_probabilities, column_probabilities, value = get_game_solution(game_array)
+        # Round the mixed strategies once, when the matrix is first solved, rather
+        # than on every one of the ~950k labelling passes that share these cached
+        # solutions. Only the strategies are rounded; the value keeps full
+        # precision because it is what propagates up the tree.
+        row_probabilities = [round(probability, 3) for probability in row_probabilities]
+        column_probabilities = [round(probability, 3) for probability in column_probabilities]
+        game_solution_cache[game_array_hash] = [row_probabilities, column_probabilities, value]
 
-    game_strategy = [[], [], game_solution[2]]
-
-    if (len(friendly_team_options) != len(game_solution[0])):
+    if len(friendly_team_options) != len(row_probabilities):
         raise ValueError("Inconsistent friendly team options.")
 
-    for i in range(0, len(friendly_team_options)):
-        game_strategy[0].append([friendly_team_options[i], round(game_solution[0][i], 3)])
-
-    if (len(enemy_team_options) != len(game_solution[1])):
+    if len(enemy_team_options) != len(column_probabilities):
         raise ValueError("Inconsistent enemy team options.")
 
-    for i in range(0, len(enemy_team_options)):
-        game_strategy[1].append([enemy_team_options[i], round(game_solution[1][i], 3)])
-
-    return game_strategy
-
-
-# Returns overview of first equilibrium.
-def get_game_overview_from_equilibria(game, equilibria):
-    for equilibrium in equilibria:
-        row_strategy = equilibrium[0]
-        column_strategy = equilibrium[1]
-
-        try:
-            value = game[row_strategy, column_strategy][0]
-        except:
-            print(game)
-            print(row_strategy)
-            print(column_strategy)
-            raise SystemError()
-        return [row_strategy, column_strategy, value]
-
-    return None
+    return [
+        [[option, probability] for option, probability in zip(friendly_team_options, row_probabilities)],
+        [[option, probability] for option, probability in zip(enemy_team_options, column_probabilities)],
+        value,
+    ]
 
 
 def print_overview(game_overview, roundTo=3):

--- a/drafter/common/utilities.py
+++ b/drafter/common/utilities.py
@@ -114,7 +114,10 @@ def solve_larger_zero_sum_game(a):
 # differ only by a constant, common on the discrete rating scale, share one LP
 # solve. Cache the shifted matrix's solution (strategies + shifted value); each
 # caller adds back its own shift. Complements the per-stage matrix-hash caches in
-# games.py, which catch bit-identical (un-shifted) matrices.
+# games.py, which catch bit-identical (un-shifted) matrices. The key carries the
+# shape as well as the bytes -- .tobytes() alone would let, say, a 2xN and an Nx2
+# matrix with the same element sequence collide -- and is the (shape, bytes) pair
+# itself, not its hash, so distinct matrices can never alias to one entry.
 normalised_game_solution_cache = {}
 
 
@@ -132,12 +135,14 @@ def solve_zero_sum_game_by_linear_program(a):
     shift = a.min()
     positive_a = a - shift + 1.0
 
-    cache_key = hash(positive_a.tobytes())
+    cache_key = (positive_a.shape, positive_a.tobytes())
     solution = normalised_game_solution_cache.get(cache_key)
     if solution is None:
         solution = solve_positivity_shifted_matrix_game(positive_a)
         normalised_game_solution_cache[cache_key] = solution
 
+    # solution's strategy lists are the shared cache entry; callers treat them as
+    # read-only (get_game_strategy rebuilds rounded copies, never mutates them).
     row_strategy, column_strategy, shifted_value = solution
 
     return [row_strategy, column_strategy, shifted_value + shift - 1.0]
@@ -167,7 +172,7 @@ def solve_positivity_shifted_matrix_game(positive_a):
 
 
 def get_game_strategy(game_solution_cache, game_array, friendly_team_options, enemy_team_options):
-    game_array_hash = hash(game_array.tostring())
+    game_array_hash = hash(game_array.tobytes())
 
     if game_array_hash in game_solution_cache:
         row_probabilities, column_probabilities, value = game_solution_cache[game_array_hash]

--- a/drafter/tests/_solve_fixture.py
+++ b/drafter/tests/_solve_fixture.py
@@ -68,8 +68,7 @@ result = {
 }
 
 # Isolate the JSON payload with sentinels so any incidental prints from the
-# solver (progress percentages, nashpy warnings routed to stdout, etc.) can't
-# be mistaken for it.
+# solver (progress percentages, etc.) can't be mistaken for it.
 print("GOLDEN_RESULT_JSON_BEGIN")
 print(json.dumps(result))
 print("GOLDEN_RESULT_JSON_END")

--- a/drafter/tests/conftest.py
+++ b/drafter/tests/conftest.py
@@ -61,8 +61,9 @@ def strategy_probabilities(strategy_entries):
 
 def support_set(strategy_entries, threshold=1e-3):
     """Names/pairs with non-negligible probability, order-independent (as a
-    frozenset of tuples) -- stable even if nashpy returns strategy vectors
-    with a different tie-break order across platforms/runs."""
+    frozenset of tuples) -- stable even if the solver returns strategy vectors
+    with a different tie-break order or picks a different (equally valid)
+    equilibrium across platforms/runs."""
     names = []
     for entry in strategy_entries:
         name = entry[0]

--- a/drafter/tests/test_golden_values.py
+++ b/drafter/tests/test_golden_values.py
@@ -23,9 +23,9 @@ be run explicitly:
 
     .venv\\Scripts\\python.exe -m pytest -m slow
 
-nashpy prints "degenerate game" RuntimeWarnings to stderr during solving on
-these fixtures -- expected given the discrete rating scale (see CLAUDE.md),
-and harmless. They are not asserted on either way.
+The direct zero-sum solver (issue #12: saddle / 2x2 closed form / one HiGHS LP)
+is deterministic and silent -- unlike nashpy, it emits no "degenerate game"
+RuntimeWarnings -- so a clean stderr is one of that issue's acceptance criteria.
 """
 import pytest
 
@@ -39,11 +39,13 @@ from drafter.tests.conftest import solve_fixture, strategy_probabilities, suppor
 # (scripts/compute_golden_value.py Smoke 4) and confirming bit-identical
 # results each time, and additionally cross-checked against an independent
 # brute-force implementation (explicit 4-player draft enumeration, zero-sum
-# games solved by scipy linprog instead of nashpy) which reproduced the value
-# to 1e-15 and the same friendly strategy; see the issue #9 PR for the run
-# outputs.
-# The value is a plain float; strategy probabilities are nashpy's own
-# `round(..., 3)` output (see drafter/common/utilities.py get_game_strategy),
+# games solved by scipy linprog) which reproduced the value to 1e-15 and the
+# same friendly strategy; see the issue #9 PR for the run outputs. The engine
+# now also solves via LP/closed form (issue #12), and this test still passes
+# bit-for-bit -- an equilibrium value is unique, so replacing the solver leaves
+# it unchanged.
+# The value is a plain float; strategy probabilities are the solver's output
+# rounded to 3 decimals (see drafter/common/utilities.py get_game_strategy),
 # so 1e-9 tolerance is appropriate there too.
 #
 # Deviation-scale correction (issue #30): value deliberately UNCHANGED. The
@@ -125,12 +127,12 @@ def test_six_player_top_level_value():
 #
 # Only the value is pinned exactly. The top-level strategy *support sets*
 # (which players get non-negligible probability) are pinned as sets, but the
-# exact probabilities are not -- support enumeration over an 8-player
-# top-level game can return different (but equally valid) equilibria/orderings
-# depending on nashpy's internal enumeration order, while the *value* of a
-# zero-sum game's equilibria is unique and stable. The support sets below have
-# been identical across independent fresh solves (2026-07, post-#32 re-pin:
-# both top-level strategies are pure).
+# exact probabilities are not -- a zero-sum game can have several equally-valid
+# equilibria, and which one a solver returns (nashpy's enumeration order, or the
+# vertex an LP lands on) is not part of the contract, while the *value* of those
+# equilibria is unique and stable. The support sets below have been identical
+# across independent fresh solves (2026-07, post-#32 re-pin: both top-level
+# strategies are pure).
 
 SCOTLAND_K = 3
 SCOTLAND_EXPECTED_VALUE = 5.875946490218083

--- a/drafter/tests/test_zero_sum_solver.py
+++ b/drafter/tests/test_zero_sum_solver.py
@@ -1,0 +1,148 @@
+"""Unit tests for the direct zero-sum game solver (GitHub issue #12 / PLAN.md
+step B1).
+
+Every game in the draft tree is zero-sum: the row (friendly) player maximises
+the payoff matrix, the column (enemy) player minimises it. utilities.
+get_game_solution solves such a game directly -- 2x2 games by closed form,
+larger games by one scipy.optimize.linprog (HiGHS) call per side -- returning
+[row_strategy, column_strategy, value].
+
+The value of a zero-sum game is unique, so it is asserted exactly. Strategies
+are checked by the equilibrium security property rather than pinned vectors:
+an equilibrium (x, y) with value v must satisfy, for the row maximiser and
+column minimiser respectively,
+
+    min_j (x . A[:, j]) >= v      (x guarantees the row player at least v)
+    max_i (A[i, :] . y) <= v      (y holds the row player to at most v)
+
+which is equilibrium-selection agnostic (any optimal vertex passes) and, taken
+together, proves v is the game value.
+"""
+import numpy as np
+import pytest
+
+import drafter.common.utilities as utilities
+
+
+def assert_valid_equilibrium(game_array, solution, tol=1e-6):
+    row_strategy, column_strategy, value = solution
+    a = np.asarray(game_array, dtype=float)
+
+    row_strategy = np.asarray(row_strategy, dtype=float)
+    column_strategy = np.asarray(column_strategy, dtype=float)
+
+    # Probability distributions.
+    assert row_strategy.shape == (a.shape[0],)
+    assert column_strategy.shape == (a.shape[1],)
+    assert row_strategy.sum() == pytest.approx(1.0, abs=tol)
+    assert column_strategy.sum() == pytest.approx(1.0, abs=tol)
+    assert (row_strategy >= -tol).all()
+    assert (column_strategy >= -tol).all()
+
+    # Security property: the row strategy guarantees at least `value` against
+    # every pure column, and the column strategy holds the row player to at
+    # most `value` against every pure row.
+    assert (row_strategy @ a).min() >= value - tol
+    assert (a @ column_strategy).max() <= value + tol
+
+
+def test_2x2_mixed_matching_pennies():
+    a = np.array([[1.0, -1.0], [-1.0, 1.0]])
+    solution = utilities.get_game_solution(a)
+    assert solution[2] == pytest.approx(0.0, abs=1e-12)
+    assert solution[0] == pytest.approx([0.5, 0.5], abs=1e-12)
+    assert solution[1] == pytest.approx([0.5, 0.5], abs=1e-12)
+    assert_valid_equilibrium(a, solution)
+
+
+def test_2x2_mixed_known_value():
+    # D = a11 + a22 - a12 - a21 = 2 + 1 + 1 + 1 = 5
+    # value = (2*1 - (-1)*(-1)) / 5 = 1/5 ; p1 = q1 = (1 - (-1)) / 5 = 0.4
+    a = np.array([[2.0, -1.0], [-1.0, 1.0]])
+    solution = utilities.get_game_solution(a)
+    assert solution[2] == pytest.approx(0.2, abs=1e-12)
+    assert solution[0] == pytest.approx([0.4, 0.6], abs=1e-12)
+    assert solution[1] == pytest.approx([0.4, 0.6], abs=1e-12)
+    assert_valid_equilibrium(a, solution)
+
+
+def test_2x2_saddle_point_pure():
+    # Row 0 has the largest row-minimum (3, at column 1); column 1 has the
+    # smallest column-maximum (3). Saddle at (0, 1) => value 3, pure strategies.
+    a = np.array([[4.0, 3.0], [2.0, 1.0]])
+    solution = utilities.get_game_solution(a)
+    assert solution[2] == pytest.approx(3.0, abs=1e-12)
+    assert solution[0] == pytest.approx([1.0, 0.0], abs=1e-12)
+    assert solution[1] == pytest.approx([0.0, 1.0], abs=1e-12)
+    assert_valid_equilibrium(a, solution)
+
+
+def test_2x2_dominated_row_saddle():
+    # Row 1 strictly dominates row 0; column then minimises down row 1.
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    solution = utilities.get_game_solution(a)
+    assert solution[2] == pytest.approx(3.0, abs=1e-12)
+    assert_valid_equilibrium(a, solution)
+
+
+def test_2x2_constant_matrix():
+    a = np.array([[5.0, 5.0], [5.0, 5.0]])
+    solution = utilities.get_game_solution(a)
+    assert solution[2] == pytest.approx(5.0, abs=1e-12)
+    assert_valid_equilibrium(a, solution)
+
+
+def test_3x3_rock_paper_scissors_via_lp():
+    a = np.array([[0.0, -1.0, 1.0], [1.0, 0.0, -1.0], [-1.0, 1.0, 0.0]])
+    solution = utilities.get_game_solution(a)
+    assert solution[2] == pytest.approx(0.0, abs=1e-9)
+    assert solution[0] == pytest.approx([1 / 3, 1 / 3, 1 / 3], abs=1e-6)
+    assert solution[1] == pytest.approx([1 / 3, 1 / 3, 1 / 3], abs=1e-6)
+    assert_valid_equilibrium(a, solution)
+
+
+def test_3x3_general_via_lp():
+    a = np.array([[3.0, -1.0, -3.0], [-2.0, 4.0, -1.0], [-5.0, -6.0, 2.0]])
+    solution = utilities.get_game_solution(a)
+    assert_valid_equilibrium(a, solution)
+
+
+def test_non_square_via_lp():
+    # 2 rows, 3 columns -- exercises the LP path with unequal dimensions.
+    a = np.array([[3.0, -1.0, 0.0], [-2.0, 1.0, 2.0]])
+    solution = utilities.get_game_solution(a)
+    assert len(solution[0]) == 2
+    assert len(solution[1]) == 3
+    assert_valid_equilibrium(a, solution)
+
+
+def test_shifted_value_translation_invariance():
+    # Adding a constant c to every payoff shifts the game value by exactly c
+    # (a check that the LP's positivity shift is undone correctly).
+    a = np.array([[0.0, -1.0, 1.0], [1.0, 0.0, -1.0], [-1.0, 1.0, 0.0]])
+    base = utilities.get_game_solution(a)[2]
+    shifted = utilities.get_game_solution(a + 7.0)[2]
+    assert shifted == pytest.approx(base + 7.0, abs=1e-9)
+
+
+# A spread of 2x2 matrices covering mixed, dominated-row, dominated-column and
+# degenerate (repeated / zero-denominator) cases. The closed form must return
+# a valid equilibrium and the unique game value for every one of them.
+CLOSED_FORM_CASES = [
+    [[1.0, -1.0], [-1.0, 1.0]],
+    [[2.0, -3.0], [-4.0, 1.0]],
+    [[0.0, 4.0], [4.0, 0.0]],
+    [[4.0, 3.0], [2.0, 1.0]],      # saddle
+    [[1.0, 2.0], [3.0, 4.0]],      # dominated row
+    [[5.0, 1.0], [4.0, 2.0]],      # dominated column
+    [[-2.0, -2.0], [-2.0, -2.0]],  # constant
+    [[10.0, -10.0], [-5.0, 5.0]],
+    [[0.5, -0.5], [-0.25, 0.75]],
+]
+
+
+@pytest.mark.parametrize("matrix", CLOSED_FORM_CASES)
+def test_closed_form_2x2_is_valid_equilibrium(matrix):
+    a = np.array(matrix)
+    solution = utilities.get_game_solution(a)
+    assert_valid_equilibrium(a, solution)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,6 @@ dependencies = [
     "Deprecated==1.2.14",
     "inquirerpy==0.3.4",
     "loguru==0.7.2",
-    "nashpy==0.0.41",
-    "networkx==3.3",
     "numpy==2.0.0",
     "pfzy==0.3.4",
     "prompt_toolkit==3.0.47",

--- a/scripts/brute_force_oracle.py
+++ b/scripts/brute_force_oracle.py
@@ -2,9 +2,11 @@
 
 Shares NO solver code with the drafter package: reads the two CSVs directly,
 enumerates the draft explicitly, and solves every zero-sum stage game with
-scipy's linear-programming solver (drafter uses nashpy enumeration instead).
-Used to cross-check golden values whenever the value model or the solver
-changes (issues #9, #30, #32).
+scipy's linear-programming solver. The engine now also solves by LP/closed form
+(issue #12) rather than nashpy, but this oracle stays a genuinely independent
+check -- its own explicit recursion, its own LP formulation. Used to cross-check
+golden values whenever the value model or the solver changes (issues #9, #30,
+#32, #12).
 
 Model (11th edition, PLAN.md workstream C):
   - defender picks the map: friendly defender -> best-map value, enemy


### PR DESCRIPTION
Closes #12.

Every game in the draft tree is zero-sum, but was solved with nashpy's general-bimatrix support enumeration and its degenerate-game fallback chain (support → vertex → Lemke-Howson) — slow on the discrete rating scale, and it prints "degenerate game" RuntimeWarnings. This replaces it with a direct zero-sum solver in `utilities.get_game_solution`.

## What changed

`get_game_solution(game_array)` now solves a zero-sum matrix game (row = friendly/maximiser, column = enemy/minimiser) directly:

1. **Pure saddle point** when one exists — `maximin == minimax` over pure strategies. On the Scotland k=3 tree ~half of the non-2×2 games have one, so no LP is needed for them.
2. **2×2 closed form** otherwise (the ~90% common case). Entries are pulled out with `.tolist()` so it's plain-float arithmetic.
3. **One `scipy.optimize.linprog` (HiGHS) call** otherwise. The column player's strategy is read from the LP **dual** (the inequality-constraint marginals), so a single solve yields both sides — no symmetric second LP.

Two matrix-hash caches:
- the existing per-stage bit-identical caches in `games.py`;
- a new **translation-normalised** cache (`normalised_game_solution_cache`) — zero-sum strategies and value are invariant under adding a constant to every payoff, so matrices that differ only by a constant (common on the discrete scale) share one LP solve (~21% fewer LP solves on Scotland k=3).

Removes the `nashpy` dependency, and `networkx` (only nashpy pulled it in — nothing imports it).

## Acceptance criteria (issue #12), on the reference machine (Ryzen 9800X3D)

| Criterion | Result |
|---|---|
| Golden values unchanged | ✅ Scotland k=3 top-level value **bit-identical** (`5.875946490218083`), support sets unchanged; Smoke/Six exact; slow test green |
| Scotland k=3 strategy phase < 30 s (baseline 275 s) | ✅ **~28.5–29.2 s** (≈9×) |
| No RuntimeWarnings | ✅ stderr clean |
| Remove nashpy | ✅ removed from `pyproject.toml`; no code imports it |

## Tests

- New `drafter/tests/test_zero_sum_solver.py`: closed-form / saddle / LP paths, each checked by the **equilibrium security property** (`min_j x·A[:,j] ≥ v ≥ max_i A[i,:]·y`) rather than pinned strategy vectors — so it's equilibrium-selection agnostic while pinning the (unique) value.
- Full fast suite: **70 passed**. Slow Scotland golden test: **passed**.

## Notes

- The remaining strategy-phase cost is split between the ~35k genuinely-mixed LP solves (scipy's `linprog` per-call *wrapper* overhead, ~250 µs, dominates for these tiny 3×3 games) and the string-keyed gamestate iteration — the latter is what **B2 (integer state encoding)** targets. A pure-saddle fast path was added (beyond the issue's literal "2×2 closed form + LP") to halve the LP count and clear the 30 s target.
- Cache format marker deliberately **not** bumped: the value model is unchanged (equilibrium values are unique), so caches solved under nashpy load with correct values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)