### PR TITLE
B2b: packed-integer gamestate keys, index-based engine (#13)

### DIFF
--- a/drafter/common/game_state.py
+++ b/drafter/common/game_state.py
@@ -8,9 +8,11 @@ class GameState:
         self.friendly_team_permutation = friendly_team_permutation
         self.enemy_team_permutation = enemy_team_permutation
 
-    def get_key(self, leading_whitespace = ""):
-        return "{}Friends: {}\n{}Enemies: {}".format(leading_whitespace, self.friendly_team_permutation.get_key(), 
-            leading_whitespace, self.enemy_team_permutation.get_key())
+    def get_key(self):
+        # A gamestate key is the pair of packed-integer team-permutation codes
+        # (GitHub issue #13, B2). Hashable and compact; names are resolved only
+        # at the presentation layer.
+        return (self.friendly_team_permutation.get_key(), self.enemy_team_permutation.get_key())
 
     def get_n(self):
         friendly_n = self.friendly_team_permutation.get_n()
@@ -67,9 +69,9 @@ def get_next_gamestate_matrix(ctx, gamestate):
 
 
 def get_gamestate_from_key(key):
-    friendly_team_representation, enemy_team_representation = key.split('\n', 1)
-    friendly_team_permutation = team_permutation.get_team_permutation_from_key(friendly_team_representation)
-    enemy_team_permutation = team_permutation.get_team_permutation_from_key(enemy_team_representation)
+    friendly_code, enemy_code = key
+    friendly_team_permutation = team_permutation.get_team_permutation_from_key(friendly_code)
+    enemy_team_permutation = team_permutation.get_team_permutation_from_key(enemy_code)
     draft_stage = friendly_team_permutation.get_draft_stage()
 
     return GameState(draft_stage, friendly_team_permutation, enemy_team_permutation)

--- a/drafter/common/packing.py
+++ b/drafter/common/packing.py
@@ -1,0 +1,96 @@
+"""Packed-integer encoding of team permutations and gamestates (GitHub issue
+#13, B2). Replaces the verbose human-readable string keys.
+
+A team permutation over <=8 players packs into a 24-bit int:
+
+    bits  0..7  : remaining-players bitmask (bit i set => player i remains)
+    bits  8..11 : defender           (4 bits, ROLE_NONE = 0xF when unset)
+    bits 12..15 : attacker_A         (4 bits)
+    bits 16..19 : attacker_B         (4 bits)
+    bits 20..23 : discarded_attacker (4 bits)
+
+Indices are per side (friendly = CSV rows, enemy = CSV columns), 0..n-1. A
+gamestate key is the pair (friendly_code, enemy_code); the draft stage is
+derivable from either code (see draft_stage_of_code). Names live only in the
+presentation layer (drafter.solver.context NameIndex).
+"""
+from drafter.common.draft_stage import DraftStage
+
+ROLE_NONE = 0xF
+
+_DEFENDER_SHIFT = 8
+_ATTACKER_A_SHIFT = 12
+_ATTACKER_B_SHIFT = 16
+_DISCARDED_SHIFT = 20
+_ROLE_MASK = 0xF
+_REMAINING_MASK = 0xFF
+
+
+def _pack_role(index):
+    return ROLE_NONE if index is None else index
+
+
+def _unpack_role(code, shift):
+    value = (code >> shift) & _ROLE_MASK
+    return None if value == ROLE_NONE else value
+
+
+def mask_from_indices(indices):
+    mask = 0
+    for index in indices:
+        mask |= (1 << index)
+    return mask
+
+
+def indices_from_mask(mask):
+    # Ascending index order -- reproduces the old "remaining players sorted"
+    # canonicalisation for free (a bitmask is inherently order-free).
+    return [i for i in range(8) if mask & (1 << i)]
+
+
+def encode_team_permutation(remaining_mask, defender, attacker_a, attacker_b, discarded):
+    return (remaining_mask
+            | (_pack_role(defender) << _DEFENDER_SHIFT)
+            | (_pack_role(attacker_a) << _ATTACKER_A_SHIFT)
+            | (_pack_role(attacker_b) << _ATTACKER_B_SHIFT)
+            | (_pack_role(discarded) << _DISCARDED_SHIFT))
+
+
+def decode_team_permutation(code):
+    """Return (remaining_mask, defender, attacker_A, attacker_B, discarded);
+    roles are int index or None."""
+    return (
+        code & _REMAINING_MASK,
+        _unpack_role(code, _DEFENDER_SHIFT),
+        _unpack_role(code, _ATTACKER_A_SHIFT),
+        _unpack_role(code, _ATTACKER_B_SHIFT),
+        _unpack_role(code, _DISCARDED_SHIFT),
+    )
+
+
+def team_permutation_n(code):
+    """Number of players on this team: popcount(remaining) + roles set. Mirrors
+    the old TeamPermutation.get_n (remaining + defender + both attackers)."""
+    remaining_mask, defender, attacker_a, attacker_b, _discarded = decode_team_permutation(code)
+    n = bin(remaining_mask).count("1")
+    if defender is not None:
+        n += 1
+    if attacker_a is not None:
+        n += 1
+    if attacker_b is not None:
+        n += 1
+    return n
+
+
+def draft_stage_of_code(code):
+    """Derive the draft stage from which roles are set, mirroring the old
+    TeamPermutation.get_draft_stage."""
+    _remaining_mask, defender, attacker_a, _attacker_b, discarded = decode_team_permutation(code)
+    if discarded is not None:
+        return DraftStage.discard_attacker
+    elif attacker_a is not None:
+        return DraftStage.select_attackers
+    elif defender is not None:
+        return DraftStage.select_defender
+    else:
+        return DraftStage.none

--- a/drafter/common/pairing.py
+++ b/drafter/common/pairing.py
@@ -1,66 +1,56 @@
 from dataclasses import dataclass  # standard libraries
+from enum import Enum
 
-import drafter.common.utilities as utilities  # local source
+import numpy as np  # 3rd party packages
 
 
-# All pairing values for one match, bundled with the neutral-map weight so the
-# defender-picks-the-map rule (11th-edition, PLAN.md workstream C) lives in one
-# place instead of reading module-level globals. Replaces the old
-# match_info.pairing_dictionary_best/worst + settings.neutral_map_weight trio
-# and the free functions utilities.get_pairing_value / get_pairing_string /
-# get_neutral_value (GitHub issue #13, B2 solver-context refactor). The tables
-# stay name-keyed dicts ({friendly: {enemy: value}}) at this step; the packed
-# integer encoding (B2 second PR) turns them into index-keyed arrays.
-@dataclass(frozen=True)
+class Defender(Enum):
+    FRIENDLY = 0
+    ENEMY = 1
+
+
+# All pairing values for one match as index-keyed numpy arrays (GitHub issue #13,
+# B2). Rows are friendly players, columns enemy players, both in NAME-SORTED index
+# order (see context.NameIndex); every value is from the friendly side's
+# perspective. Replaces the name-keyed dicts and the free functions
+# utilities.get_pairing_value / get_neutral_value. The defender-picks-the-map rule
+# (11th-edition, PLAN.md workstream C) lives in `value`.
+@dataclass(eq=False)
 class PairingTables:
-    best: dict
-    worst: dict
+    best: np.ndarray                  # (n_friendly, n_enemy)
+    worst: np.ndarray
     neutral_weight: float
 
-    # The defender picks the map: a friendly defender gets the pairing's best-map
-    # value, an enemy defender forces the worst-map value, and games without a
-    # defender (refused-vs-refused, last players) fall neutral_weight of the way
-    # from worst to best.
-    def value(self, friendly_player, enemy_player, defender=None):
-        best_value = utilities.get_value_from_input_dictionary(self.best, friendly_player, enemy_player)
-        worst_value = utilities.get_value_from_input_dictionary(self.worst, friendly_player, enemy_player)
+    @classmethod
+    def from_dicts(cls, best, worst, friendly, enemy, neutral_weight):
+        """Build the arrays from the name-keyed CSV dicts and the two NameIndex
+        maps ({friendly_name: {enemy_name: value}})."""
+        best_array = np.zeros((len(friendly.names), len(enemy.names)), dtype=float)
+        worst_array = np.zeros_like(best_array)
 
+        for source, target in ((best, best_array), (worst, worst_array)):
+            for friendly_name, row in source.items():
+                i = friendly.index(friendly_name)
+                for enemy_name, value in row.items():
+                    target[i, enemy.index(enemy_name)] = value
+
+        return cls(best_array, worst_array, neutral_weight)
+
+    # A friendly defender gets the pairing's best-map value, an enemy defender
+    # forces the worst-map value, and games without a defender (refused-vs-refused,
+    # last players) fall neutral_weight of the way from worst to best.
+    def value(self, friendly_index, enemy_index, defender=None):
         if defender is None:
-            return worst_value + self.neutral_weight * (best_value - worst_value)
-        elif friendly_player == defender:
-            return best_value
-        elif enemy_player == defender:
-            return worst_value
+            best_value = self.best[friendly_index, enemy_index]
+            worst_value = self.worst[friendly_index, enemy_index]
+            return float(worst_value + self.neutral_weight * (best_value - worst_value))
+        elif defender == Defender.FRIENDLY:
+            return float(self.best[friendly_index, enemy_index])
+        elif defender == Defender.ENEMY:
+            return float(self.worst[friendly_index, enemy_index])
         else:
             raise ValueError("Unknown defender: {}".format(defender))
 
-    def pairing_string(self, friendly_player, enemy_player, defender=None):
-        value = self.value(friendly_player, enemy_player, defender)
-
-        friendly_player_string = friendly_player
-        enemy_player_string = enemy_player
-
-        if defender is not None:
-            if friendly_player == defender:
-                friendly_player_string += " (D)"
-            elif enemy_player == defender:
-                enemy_player_string += " (D)"
-            else:
-                raise ValueError("Unknown defender: {}".format(defender))
-
-        return round(value, 2), "{} vs {}".format(friendly_player_string, enemy_player_string)
-
-    # The full neutral (no-defender) matrix, used by the k-restriction heuristic
-    # to value an attacker's games against the yet-undefended field.
-    def neutral_dictionary(self):
-        neutral_pairing_dictionary = {}
-
-        for friend in self.best:
-            row = {}
-            for enemy in self.best[friend]:
-                best_value = self.best[friend][enemy]
-                worst_value = self.worst[friend][enemy]
-                row[enemy] = worst_value + self.neutral_weight * (best_value - worst_value)
-            neutral_pairing_dictionary[friend] = row
-
-        return neutral_pairing_dictionary
+    # The full neutral (no-defender) matrix, for the k-restriction heuristic.
+    def neutral_matrix(self):
+        return self.worst + self.neutral_weight * (self.best - self.worst)

--- a/drafter/common/team_permutation.py
+++ b/drafter/common/team_permutation.py
@@ -2,9 +2,9 @@ import itertools  # standard libraries
 from copy import deepcopy
 from dataclasses import dataclass
 from enum import Enum
-import re
 
 import drafter.common.utilities as utilities  # local source
+import drafter.common.packing as packing
 from drafter.common.draft_stage import DraftStage
 
 
@@ -16,15 +16,17 @@ class Side(Enum):
 # Precomputed pairing lookups for the k-restriction heuristic (which attackers a
 # team plausibly fields against a given defender). Built once per solve from the
 # match's PairingTables; replaces the module-level globals that used to be set by
-# enable_restricted_attackers() (GitHub issue #13). All values are from the
-# friendly side's perspective.
-@dataclass(frozen=True)
+# enable_restricted_attackers() (GitHub issue #13). All arrays are indexed by
+# name-sorted player index and hold values from the friendly side's perspective:
+# friendly_* arrays are (n_friendly, n_enemy), enemy_* arrays are (n_enemy,
+# n_friendly) so [attacker, opponent] indexing works for either side.
+@dataclass(eq=False)
 class RestrictionData:
     k: int
-    friendly_vs_defender: dict
-    friendly_vs_field: dict
-    enemy_vs_defender: dict
-    enemy_vs_field: dict
+    friendly_vs_defender: object
+    friendly_vs_field: object
+    enemy_vs_defender: object
+    enemy_vs_field: object
 
 
 class TeamPermutation:
@@ -44,23 +46,9 @@ class TeamPermutation:
         self.remaining_players = sorted(remaining_players)
 
     def get_key(self):
-        permutation_key = ""
-
-        if self.defender is not None:
-            permutation_key += "{{Defender: {}}}".format(self.defender) + ", "
-
-        if self.attacker_A is not None:
-            permutation_key += "{{Attacker A: {}}}".format(self.attacker_A) + ", "
-
-        if self.attacker_B is not None:
-            permutation_key += "{{Attacker B: {}}}".format(self.attacker_B) + ", "
-
-        if self.discarded_attacker is not None:
-            permutation_key += "{{Discarded attacker: {}}}".format(self.discarded_attacker) + ", "
-
-        permutation_key += "{{Remaining players: {}}}".format(", ".join(self.remaining_players))
-
-        return permutation_key
+        return packing.encode_team_permutation(
+            packing.mask_from_indices(self.remaining_players),
+            self.defender, self.attacker_A, self.attacker_B, self.discarded_attacker)
 
     def get_draft_stage(self):
         if self.discarded_attacker is not None:
@@ -125,35 +113,12 @@ class TeamPermutation:
             raise ValueError("Unknown discarded attacker: {}".format(discarded_attacker))
 
 
-def get_team_permutation_from_key(key):
-    role_string, remaining_players_string = key.split("{Remaining players: ", 1)
+def get_team_permutation_from_key(code):
+    remaining_mask, defender, attacker_A, attacker_B, discarded_attacker = \
+        packing.decode_team_permutation(code)
+    remaining_players = packing.indices_from_mask(remaining_mask)
 
-    remaining_players_string = remaining_players_string.strip('}')
-    remaining_players = remaining_players_string.split(', ')
-
-    defender = None
-    attacker_A = None
-    attacker_B = None
-    discarded_attacker = None
-
-    groups = re.findall(r'\{.*?\}', role_string)
-    for group in groups:
-        role, player = group.split(': ')
-        role = role.strip('{')
-        player = player.strip('}')
-
-        if role == "Defender":
-            defender = player
-        elif role == "Attacker A":
-            attacker_A = player
-        elif role == "Attacker B":
-            attacker_B = player
-        elif role == "Discarded attacker":
-            discarded_attacker = player
-        else:
-            raise ValueError("Unknown role {}.".format(role))
-
-    return(TeamPermutation(remaining_players, defender, attacker_A, attacker_B, discarded_attacker))
+    return TeamPermutation(remaining_players, defender, attacker_A, attacker_B, discarded_attacker)
 
 
 def get_team_permutation(draft_stage, players):
@@ -272,19 +237,20 @@ def get_attackers_team_permutations(ctx, side, defender_team_permutation, opposi
 
 
 def build_restriction(pairing, k):
-    neutral_pairing_dictionary = pairing.neutral_dictionary()
+    neutral_matrix = pairing.neutral_matrix()
 
     # All values are from the friendly side's perspective. An attacker plays the
     # opposing defender, who picks the map: a friendly attacker gets the pairing's
     # worst-map value, an enemy attacker faces the friendly defender's best-map
     # value. Games against the rest of the field have no defender yet, so they
-    # use the neutral (weighted-midpoint) value.
+    # use the neutral (weighted-midpoint) value. Enemy arrays are transposed so
+    # [attacker, opponent] indexes an (enemy, friendly) pair.
     return RestrictionData(
         k=k,
         friendly_vs_defender=pairing.worst,
-        friendly_vs_field=neutral_pairing_dictionary,
-        enemy_vs_defender=utilities.get_transposed_pairing_dictionary(pairing.best),
-        enemy_vs_field=utilities.get_transposed_pairing_dictionary(neutral_pairing_dictionary))
+        friendly_vs_field=neutral_matrix,
+        enemy_vs_defender=pairing.best.T,
+        enemy_vs_field=neutral_matrix.T)
 
 
 def get_heuristically_best_attackers(restriction, side, eligable_attackers, opposing_defender_team_permutation):
@@ -293,20 +259,23 @@ def get_heuristically_best_attackers(restriction, side, eligable_attackers, oppo
     # directions. The explicit `side` replaces the old trick of sniffing which
     # pairing dictionary an attacker name appeared in (GitHub issue #13).
     if side == Side.FRIENDLY:
-        vs_defender_dictionary = restriction.friendly_vs_defender
-        vs_field_dictionary = restriction.friendly_vs_field
+        vs_defender_array = restriction.friendly_vs_defender
+        vs_field_array = restriction.friendly_vs_field
         ranking_sign = -1
     else:
-        vs_defender_dictionary = restriction.enemy_vs_defender
-        vs_field_dictionary = restriction.enemy_vs_field
+        vs_defender_array = restriction.enemy_vs_defender
+        vs_field_array = restriction.enemy_vs_field
         ranking_sign = 1
+
+    opposing_defender = opposing_defender_team_permutation.defender
+    opposing_remaining = opposing_defender_team_permutation.remaining_players
 
     attackers_with_relative_advantages_against_defender = []
 
     for attacker in eligable_attackers:
-        vs_defender = vs_defender_dictionary[attacker][opposing_defender_team_permutation.defender]
-        vs_field = sum([vs_field_dictionary[attacker][opponent] for opponent in opposing_defender_team_permutation.remaining_players]) \
-            / len(opposing_defender_team_permutation.remaining_players)
+        vs_defender = vs_defender_array[attacker][opposing_defender]
+        vs_field = sum([vs_field_array[attacker][opponent] for opponent in opposing_remaining]) \
+            / len(opposing_remaining)
 
         relative_advantage = vs_defender - vs_field
         attackers_with_relative_advantages_against_defender.append([attacker, relative_advantage])

--- a/drafter/common/utilities.py
+++ b/drafter/common/utilities.py
@@ -4,21 +4,6 @@ import numpy as np  # 3rd party packages
 from scipy.optimize import linprog
 
 
-def get_transposed_pairing_dictionary(pairing_dictionary):
-    friends = [friend for friend in pairing_dictionary]
-    enemies = [enemy for enemy in pairing_dictionary[friends[0]]]
-
-    transposed_pairing_dictionary = {}
-
-    for enemy in enemies:
-        row = {}
-        for friend in friends:
-            row[friend] = pairing_dictionary[friend][enemy]
-        transposed_pairing_dictionary[enemy] = row
-
-    return transposed_pairing_dictionary
-
-
 # Every game in the draft tree is zero-sum: the row (friendly) player maximises
 # `game_array`, the column (enemy) player minimises it. Solve it directly rather
 # than by nashpy's general-bimatrix support enumeration (issue #12 / PLAN.md B1):
@@ -270,17 +255,3 @@ def get_arbitrary_dictionary_entry(dictionary):
         return arbitrary_dictionary_entry
     else:
         return None
-
-
-def get_value_from_input_dictionary(input_dictionary, friendly_player, enemy_player):
-    if friendly_player in input_dictionary:
-        row = input_dictionary[friendly_player]
-    else:
-        raise ValueError("Unknown player: {}".format(friendly_player))
-
-    if enemy_player in row:
-        value = row[enemy_player]
-    else:
-        raise ValueError("Unknown player: {}".format(enemy_player))
-
-    return value

--- a/drafter/data/initialise_dictionaries.py
+++ b/drafter/data/initialise_dictionaries.py
@@ -21,7 +21,11 @@ def initialise(enemy_team_name, config):
         utilities.get_path(enemy_team_name, "pairing_matrix_worst.csv"), config.require_unique_names)
     validate_best_not_below_worst(best, worst)
 
-    pairing = PairingTables(best, worst, config.neutral_map_weight)
+    # Assign player indices in name-sorted order (see context.NameIndex): enemy
+    # names are the columns of any friendly row.
+    friendly = context.NameIndex.from_names(best.keys())
+    enemy = context.NameIndex.from_names(next(iter(best.values())).keys())
+    pairing = PairingTables.from_dicts(best, worst, friendly, enemy, config.neutral_map_weight)
 
     restriction = None
     if config.restrict_attackers:
@@ -30,18 +34,24 @@ def initialise(enemy_team_name, config):
     ctx = context.SolverContext(
         config=config,
         enemy_team_name=enemy_team_name,
+        friendly=friendly,
+        enemy=enemy,
         pairing=pairing,
         restriction=restriction,
         gamestate_dictionaries=game_state_dictionaries.make_gamestate_dictionaries(),
         strategy_dictionaries=strategy_dictionaries.make_strategy_dictionaries(),
         game_solution_caches=games.make_game_solution_caches())
 
-    # Cached JSONs carry solved game values, so caches written under an older
-    # value model would load fine but be silently wrong. Only read them if the
-    # match folder's format marker matches the current engine; the marker is
-    # written after a successful solve+write below.
+    friendly_names = list(friendly.names)
+    enemy_names = list(enemy.names)
+
+    # Cached JSONs carry solved game values keyed by positional integer codes, so
+    # a cache written under an older value model or a different player set/order
+    # would load fine but be silently wrong. Only read caches whose marker matches
+    # the current engine and the current name ordering; the marker is written
+    # after a successful solve+write below.
     caches_are_current = read_write.cache_format_is_current(
-        utilities.get_path(enemy_team_name, read_write.CACHE_FORMAT_FILENAME))
+        utilities.get_path(enemy_team_name, read_write.CACHE_FORMAT_FILENAME), friendly_names, enemy_names)
     if (config.read_gamestates or config.read_strategies) and not caches_are_current:
         print("Ignoring cached JSONs in this match folder (missing or outdated {}): "
             "they were computed under an older value model. Solving fresh."
@@ -71,7 +81,7 @@ def initialise(enemy_team_name, config):
 
     if config.write_gamestates and config.write_strategies:
         read_write.write_cache_format_marker(
-            utilities.get_path(enemy_team_name, read_write.CACHE_FORMAT_FILENAME))
+            utilities.get_path(enemy_team_name, read_write.CACHE_FORMAT_FILENAME), friendly_names, enemy_names)
 
     return ctx
 

--- a/drafter/data/read_write.py
+++ b/drafter/data/read_write.py
@@ -4,27 +4,42 @@ import json  # standard libraries
 # Caches carry solved game values, so any change to the value model makes old
 # caches silently wrong (they would load fine and give plausible numbers).
 # Bump this whenever cached values are no longer comparable with the current
-# engine. Version 4 = discard_attacker returns the refused attackers to the
-# child pools (issue #32); version 3 = numeric ratings on the deviation scale,
+# engine. Version 5 = packed-integer gamestate keys, index-keyed strategy values
+# (issue #13, B2); version 4 = discard_attacker returns the refused attackers to
+# the child pools (issue #32); version 3 = numeric ratings on the deviation scale,
 # internal = score - 10 (issue #30); version 2 = the 11th-edition best/worst
 # map model (issue #9) with the mistaken 2*(score-10) conversion; version 1
 # (implicit -- no marker file existed) = the old map-importance model.
-CACHE_FORMAT_VERSION = 4
+CACHE_FORMAT_VERSION = 5
 CACHE_FORMAT_FILENAME = "cache_format.json"
 
 
-def cache_format_is_current(path):
+def cache_format_is_current(path, friendly_names=None, enemy_names=None):
+    # The packed-integer keys are positional (index = name-sorted CSV position),
+    # so a cache is only valid if the current CSVs have the same player names in
+    # the same order. When names are supplied, reject the cache on any mismatch
+    # (issue #13, B2) -- cheap insurance against silent index-remap corruption.
     try:
         with path.open('r', encoding='utf-8') as data_file:
             marker = json.load(data_file)
-        return marker.get("cache_format_version") == CACHE_FORMAT_VERSION
+        if marker.get("cache_format_version") != CACHE_FORMAT_VERSION:
+            return False
+        if friendly_names is not None and marker.get("friendly_names") != list(friendly_names):
+            return False
+        if enemy_names is not None and marker.get("enemy_names") != list(enemy_names):
+            return False
+        return True
     except (OSError, ValueError, AttributeError):
         return False
 
 
-def write_cache_format_marker(path):
+def write_cache_format_marker(path, friendly_names=None, enemy_names=None):
+    marker = {"cache_format_version": CACHE_FORMAT_VERSION}
+    if friendly_names is not None:
+        marker["friendly_names"] = list(friendly_names)
+        marker["enemy_names"] = list(enemy_names)
     with path.open('w', encoding='utf-8') as f:
-        json.dump({"cache_format_version": CACHE_FORMAT_VERSION}, f)
+        json.dump(marker, f)
 
 
 def read_dictionary(path):

--- a/drafter/solver/context.py
+++ b/drafter/solver/context.py
@@ -2,6 +2,29 @@ from dataclasses import dataclass  # standard libraries
 from typing import Any
 
 
+# Index <-> name bridge for one team (GitHub issue #13, B2). Player indices are
+# assigned in NAME-SORTED order, deliberately matching the ordering the string-key
+# engine used everywhere (TeamPermutation sorted names), so switching to packed
+# integer keys is a pure relabelling: enumeration order, payoff-matrix row/column
+# order and equilibrium selection are all unchanged. Names live only here, at the
+# presentation layer.
+@dataclass(frozen=True)
+class NameIndex:
+    names: tuple            # index -> name, name-sorted
+    index_of: dict          # name -> index
+
+    def name(self, index):
+        return self.names[index]
+
+    def index(self, name):
+        return self.index_of[name]
+
+    @classmethod
+    def from_names(cls, names):
+        ordered = tuple(sorted(names))
+        return cls(ordered, {name: i for i, name in enumerate(ordered)})
+
+
 # All the knobs that used to live as mutable module-level globals in
 # drafter/data/settings.py. Frozen so a solve can't silently mutate its own
 # configuration mid-run; build a new one to change a knob (GitHub issue #13,
@@ -43,6 +66,8 @@ class SolverConfig:
 class SolverContext:
     config: SolverConfig
     enemy_team_name: Any
+    friendly: NameIndex               # index <-> name for the friendly team
+    enemy: NameIndex                  # index <-> name for the enemy team
     pairing: Any                      # drafter.common.pairing.PairingTables
     restriction: Any                  # team_permutation.RestrictionData | None
     gamestate_dictionaries: dict

--- a/drafter/solver/context.py
+++ b/drafter/solver/context.py
@@ -59,9 +59,9 @@ class SolverConfig:
 # module-level globals (GitHub issue #13). Replaces drafter.data.match_info, the
 # mutable drafter.data.settings, the restrict-attackers caches that used to live
 # in drafter.common.team_permutation, and the gamestate/strategy dictionaries
-# that used to be module globals in the solver package. Names still live in the
-# key strings at this step; the packed-integer encoding (B2 second PR) moves the
-# name<->index maps here too.
+# that used to be module globals in the solver package. Gamestate keys are packed
+# integers (drafter.common.packing); the friendly/enemy NameIndex maps here are
+# the only place player names live.
 @dataclass
 class SolverContext:
     config: SolverConfig

--- a/drafter/solver/draft.py
+++ b/drafter/solver/draft.py
@@ -7,11 +7,51 @@ import drafter.common.team_permutation as team_permutation
 from drafter.common.game_state import GameState
 import drafter.common.draft_stage as draft_stage
 from drafter.common.draft_stage import DraftStage
+from drafter.common.pairing import Defender
 import drafter.solver.strategy_dictionaries as strategy_dictionaries
 import drafter.solver.game_state_dictionaries as game_state_dictionaries
 
 keyword_quit = "quit()"
 keyword_back = "back()"
+
+
+# --- presentation helpers: the engine works in integer indices, names live only
+# here (GitHub issue #13, B2) ---
+
+def format_team_permutation(name_index, tp):
+    parts = []
+    if tp.defender is not None:
+        parts.append("{{Defender: {}}}".format(name_index.name(tp.defender)))
+    if tp.attacker_A is not None:
+        parts.append("{{Attacker A: {}}}".format(name_index.name(tp.attacker_A)))
+    if tp.attacker_B is not None:
+        parts.append("{{Attacker B: {}}}".format(name_index.name(tp.attacker_B)))
+    if tp.discarded_attacker is not None:
+        parts.append("{{Discarded attacker: {}}}".format(name_index.name(tp.discarded_attacker)))
+    parts.append("{{Remaining players: {}}}".format(
+        ", ".join(name_index.name(i) for i in tp.remaining_players)))
+    return ", ".join(parts)
+
+
+def format_gamestate(ctx, gamestate, leading_whitespace=""):
+    return "{}Friends: {}\n{}Enemies: {}".format(
+        leading_whitespace, format_team_permutation(ctx.friendly, gamestate.friendly_team_permutation),
+        leading_whitespace, format_team_permutation(ctx.enemy, gamestate.enemy_team_permutation))
+
+
+# A (rounded value, "Friend vs Enemy" label) pairing, with " (D)" on whichever
+# side defended. friendly_index/enemy_index are per-side player indices.
+def pairing_string(ctx, friendly_index, enemy_index, defender=None):
+    value = ctx.pairing.value(friendly_index, enemy_index, defender)
+    friendly_player_string = ctx.friendly.name(friendly_index)
+    enemy_player_string = ctx.enemy.name(enemy_index)
+
+    if defender == Defender.FRIENDLY:
+        friendly_player_string += " (D)"
+    elif defender == Defender.ENEMY:
+        enemy_player_string += " (D)"
+
+    return round(value, 2), "{} vs {}".format(friendly_player_string, enemy_player_string)
 
 
 def play_draft(ctx):
@@ -38,7 +78,7 @@ def play_draft(ctx):
             counter = 1
             for pairing in pairings:
                 print("         " + "[{}] ".format(pairing[0]) + pairing[1])
-        print('\n' + current_gamestate.get_key("      ") + '\n')
+        print('\n' + format_gamestate(ctx, current_gamestate, "      ") + '\n')
         team_strategies = get_team_strategies(ctx, current_gamestate)
         current_gamestate, new_pairings = prompt_next_gamestate(ctx, current_gamestate, team_strategies, next_draft_stage)
 
@@ -142,16 +182,32 @@ def update_dictionaries(ctx, seed_gamestate):
 
 
 def prompt_next_gamestate(ctx, _gamestate, gamestate_team_strategies, next_draft_stage):
-    def print_team_options(team_name, team_permutation, team_strategy, opponent_team_permutation, show_suggestions):
+    def print_team_options(team_name, team_permutation, team_strategy, opponent_team_permutation,
+            show_suggestions, name_index, opponent_name_index):
         print("")
+        # During the discard stage a team chooses among the OPPONENT's attackers,
+        # so its options and strategy entries live in the opponent's index space.
+        choice_name_index = opponent_name_index if next_draft_stage == DraftStage.discard_attacker else name_index
+
         if next_draft_stage == DraftStage.select_defender:
-            options = team_permutation.remaining_players
+            option_indices = team_permutation.remaining_players
         elif next_draft_stage == DraftStage.select_attackers:
-            options = team_permutation.remaining_players
+            option_indices = team_permutation.remaining_players
         elif next_draft_stage == DraftStage.discard_attacker:
-            options = [opponent_team_permutation.attacker_A, opponent_team_permutation.attacker_B]
+            option_indices = [opponent_team_permutation.attacker_A, opponent_team_permutation.attacker_B]
         else:
             raise ValueError("Cannot solve draft stage {}".format(next_draft_stage))
+
+        options = [choice_name_index.name(index) for index in option_indices]
+
+        # Resolve the strategy's integer selections to names so the rest of this
+        # display/sampling logic can stay name-based, as it was before B2.
+        def to_name(selection):
+            if isinstance(selection, list):
+                return [choice_name_index.name(selection[0]), choice_name_index.name(selection[1])]
+            return choice_name_index.name(selection)
+
+        team_strategy = [[to_name(entry[0]), entry[1]] for entry in team_strategy]
 
         options_string = utilities.list_to_string(options)
 
@@ -161,7 +217,8 @@ def prompt_next_gamestate(ctx, _gamestate, gamestate_team_strategies, next_draft
             options = ["{} & {}".format(option[0], option[1]) for option in option_combinations]
 
         if ctx.config.invert_discard_attackers and next_draft_stage == DraftStage.discard_attacker:
-            print("   {} options: {} vs\n    - {}\n".format(team_name, team_permutation.defender, options_string))
+            print("   {} options: {} vs\n    - {}\n".format(
+                team_name, name_index.name(team_permutation.defender), options_string))
         else:
             print("   {} options:\n    - {}\n".format(team_name, options_string))
 
@@ -206,10 +263,12 @@ def prompt_next_gamestate(ctx, _gamestate, gamestate_team_strategies, next_draft
 
         if ctx.config.invert_discard_attackers:
             if next_draft_stage == DraftStage.discard_attacker:
-                if suggested_selection == opponent_team_permutation.attacker_A:
-                    suggested_selection = opponent_team_permutation.attacker_B
-                elif suggested_selection == opponent_team_permutation.attacker_B:
-                    suggested_selection = opponent_team_permutation.attacker_A
+                attacker_A_name = choice_name_index.name(opponent_team_permutation.attacker_A)
+                attacker_B_name = choice_name_index.name(opponent_team_permutation.attacker_B)
+                if suggested_selection == attacker_A_name:
+                    suggested_selection = attacker_B_name
+                elif suggested_selection == attacker_B_name:
+                    suggested_selection = attacker_A_name
 
         if (show_suggestions):
             print("\n    --- Suggested {} selection: {} ---\n".format(team_name, suggested_selection))
@@ -263,39 +322,45 @@ def prompt_next_gamestate(ctx, _gamestate, gamestate_team_strategies, next_draft
         pairings = []
 
         if next_gamestate_draft_stage == DraftStage.select_defender:
-            next_friendly_team_permutation.select_defender(friendly_team_selection)
-            next_enemy_team_permutation.select_defender(enemy_team_selection)
+            next_friendly_team_permutation.select_defender(ctx.friendly.index(friendly_team_selection))
+            next_enemy_team_permutation.select_defender(ctx.enemy.index(enemy_team_selection))
 
         elif next_gamestate_draft_stage == DraftStage.select_attackers:
             f_attacker_A, f_attacker_B = friendly_team_selection.split(" & ")
-            next_friendly_team_permutation.select_attackers(f_attacker_A, f_attacker_B)
+            next_friendly_team_permutation.select_attackers(
+                ctx.friendly.index(f_attacker_A), ctx.friendly.index(f_attacker_B))
 
             e_attacker_A, e_attacker_B = enemy_team_selection.split(" & ")
-            next_enemy_team_permutation.select_attackers(e_attacker_A, e_attacker_B)
+            next_enemy_team_permutation.select_attackers(
+                ctx.enemy.index(e_attacker_A), ctx.enemy.index(e_attacker_B))
 
         elif next_gamestate_draft_stage == DraftStage.discard_attacker:
-            next_friendly_team_permutation.select_discarded_attacker(enemy_team_selection)
+            # Each team refuses one of the OPPONENT's attackers, so the friendly
+            # selection is an enemy-space name and vice versa. The attacker a team
+            # discards from its own pool is the one the opponent refused.
+            f_discarded_attacker = ctx.friendly.index(enemy_team_selection)
+            e_discarded_attacker = ctx.enemy.index(friendly_team_selection)
+
+            next_friendly_team_permutation.select_discarded_attacker(f_discarded_attacker)
             next_friendly_team_permutation = team_permutation.get_none_team_permutation(next_friendly_team_permutation)
 
-            next_enemy_team_permutation.select_discarded_attacker(friendly_team_selection)
+            next_enemy_team_permutation.select_discarded_attacker(e_discarded_attacker)
             next_enemy_team_permutation = team_permutation.get_none_team_permutation(next_enemy_team_permutation)
 
             f_defender = friendly_team_permutation.defender
-            f_discarded_attacker = enemy_team_selection
             f_nondiscarded_attacker = friendly_team_permutation.get_nondiscarded_attacker(f_discarded_attacker)
             f_remaining_players = friendly_team_permutation.remaining_players
 
             e_defender = enemy_team_permutation.defender
-            e_discarded_attacker = friendly_team_selection
             e_nondiscarded_attacker = enemy_team_permutation.get_nondiscarded_attacker(e_discarded_attacker)
             e_remaining_players = enemy_team_permutation.remaining_players
 
-            pairings.append(ctx.pairing.pairing_string(f_defender, e_nondiscarded_attacker, f_defender))
-            pairings.append(ctx.pairing.pairing_string(f_nondiscarded_attacker, e_defender, e_defender))
+            pairings.append(pairing_string(ctx, f_defender, e_nondiscarded_attacker, Defender.FRIENDLY))
+            pairings.append(pairing_string(ctx, f_nondiscarded_attacker, e_defender, Defender.ENEMY))
 
             if len(f_remaining_players) == 1:
-                pairings.append(ctx.pairing.pairing_string(f_discarded_attacker, e_discarded_attacker))
-                pairings.append(ctx.pairing.pairing_string(f_remaining_players[0], e_remaining_players[0]))
+                pairings.append(pairing_string(ctx, f_discarded_attacker, e_discarded_attacker))
+                pairings.append(pairing_string(ctx, f_remaining_players[0], e_remaining_players[0]))
 
             next_gamestate_draft_stage = draft_stage.get_next_draft_stage(next_gamestate_draft_stage)
 
@@ -313,10 +378,12 @@ def prompt_next_gamestate(ctx, _gamestate, gamestate_team_strategies, next_draft
     enemy_team_strategy = gamestate_team_strategies[1]
 
     friendly_team_options, suggested_friendly_selection = print_team_options(ctx.config.friendly_team_name,
-        friendly_team_permutation, friendly_team_strategy, enemy_team_permutation, ctx.config.show_friendly_strategy_suggestions)
+        friendly_team_permutation, friendly_team_strategy, enemy_team_permutation,
+        ctx.config.show_friendly_strategy_suggestions, ctx.friendly, ctx.enemy)
 
     enemy_team_options, suggested_enemy_selection = print_team_options(ctx.enemy_team_name,
-        enemy_team_permutation, enemy_team_strategy, friendly_team_permutation, ctx.config.show_enemy_strategy_suggestions)
+        enemy_team_permutation, enemy_team_strategy, friendly_team_permutation,
+        ctx.config.show_enemy_strategy_suggestions, ctx.enemy, ctx.friendly)
 
     friendly_team_selection = None
     enemy_team_selection = None

--- a/drafter/solver/game_state_dictionaries.py
+++ b/drafter/solver/game_state_dictionaries.py
@@ -59,8 +59,9 @@ def read_dictionaries(ctx):
 def write_dictionaries(ctx):
     for name in global_gamestate_dictionary_names:
         path = utilities.get_path(ctx.enemy_team_name, name + ".json")
-        string_representation = [key for key in ctx.gamestate_dictionaries[name]]
-        read_write.write_dictionary(path, string_representation)
+        # The (friendly, enemy) integer-code tuples serialise to JSON as lists.
+        key_list = [key for key in ctx.gamestate_dictionaries[name]]
+        read_write.write_dictionary(path, key_list)
 
 
 def get_initial_game_state(ctx):

--- a/drafter/solver/game_state_dictionaries.py
+++ b/drafter/solver/game_state_dictionaries.py
@@ -46,7 +46,10 @@ def read_dictionaries(ctx):
         key_list = read_write.read_dictionary(path)
 
         if (key_list is not None and len(key_list) > 0):
-            ctx.gamestate_dictionaries[name] = {key: game_state.get_gamestate_from_key(key) for key in key_list}
+            # JSON turns the (friendly, enemy) tuple keys into 2-element lists;
+            # tuple them back so they are hashable dict keys again.
+            ctx.gamestate_dictionaries[name] = {
+                tuple(key): game_state.get_gamestate_from_key(key) for key in key_list}
         else:
             return False
 
@@ -61,8 +64,8 @@ def write_dictionaries(ctx):
 
 
 def get_initial_game_state(ctx):
-    friends = [friend for friend in ctx.pairing.best]
-    enemies = [enemy for enemy in ctx.pairing.best[friends[0]]]
+    friends = list(range(len(ctx.friendly.names)))
+    enemies = list(range(len(ctx.enemy.names)))
     initial_game_state = GameState(DraftStage.none, TeamPermutation(friends), TeamPermutation(enemies))
 
     return initial_game_state

--- a/drafter/solver/games.py
+++ b/drafter/solver/games.py
@@ -5,6 +5,7 @@ import drafter.common.game_state as game_state
 from drafter.common.game_state import GameState
 from drafter.common.team_permutation import TeamPermutation
 from drafter.common.draft_stage import DraftStage
+from drafter.common.pairing import Defender
 
 STAGES = ("select_defender", "select_attackers", "discard_attacker")
 
@@ -90,10 +91,10 @@ def discard_attacker(ctx, n, selected_attackers_gamestate, select_defender_strat
         return discard_attacker_4(ctx, f_defender, f_attacker_A, f_attacker_B, remaining_friends[0],
             e_defender, e_attacker_A, e_attacker_B, remaining_enemies[0])
 
-    fD_eA = ctx.pairing.value(f_defender, e_attacker_A, f_defender)
-    fD_eB = ctx.pairing.value(f_defender, e_attacker_B, f_defender)
-    fA_eD = ctx.pairing.value(f_attacker_A, e_defender, e_defender)
-    fB_eD = ctx.pairing.value(f_attacker_B, e_defender, e_defender)
+    fD_eA = ctx.pairing.value(f_defender, e_attacker_A, Defender.FRIENDLY)
+    fD_eB = ctx.pairing.value(f_defender, e_attacker_B, Defender.FRIENDLY)
+    fA_eD = ctx.pairing.value(f_attacker_A, e_defender, Defender.ENEMY)
+    fB_eD = ctx.pairing.value(f_attacker_B, e_defender, Defender.ENEMY)
 
     # The child gamestate receives the REFUSED attackers back into the pools
     # (issue #32): in AB, e_B plays the friendly defender and f_A plays the
@@ -114,10 +115,10 @@ def discard_attacker(ctx, n, selected_attackers_gamestate, select_defender_strat
 def discard_attacker_4(ctx, f_defender, f_attacker_A, f_attacker_B, f_not_selected, e_defender,
         e_attacker_A, e_attacker_B, e_not_selected):
 
-    fD_eA = ctx.pairing.value(f_defender, e_attacker_A, f_defender)
-    fD_eB = ctx.pairing.value(f_defender, e_attacker_B, f_defender)
-    fA_eD = ctx.pairing.value(f_attacker_A, e_defender, e_defender)
-    fB_eD = ctx.pairing.value(f_attacker_B, e_defender, e_defender)
+    fD_eA = ctx.pairing.value(f_defender, e_attacker_A, Defender.FRIENDLY)
+    fD_eB = ctx.pairing.value(f_defender, e_attacker_B, Defender.FRIENDLY)
+    fA_eD = ctx.pairing.value(f_attacker_A, e_defender, Defender.ENEMY)
+    fB_eD = ctx.pairing.value(f_attacker_B, e_defender, Defender.ENEMY)
 
     fA_eA = ctx.pairing.value(f_attacker_A, e_attacker_A)
     fA_eB = ctx.pairing.value(f_attacker_A, e_attacker_B)

--- a/drafter/solver/strategy_dictionaries.py
+++ b/drafter/solver/strategy_dictionaries.py
@@ -65,13 +65,19 @@ def process_gamestate_dictionary(ctx, read, write, gamestate_dictionary_to_solve
     draft_stage_strategies = None
 
     if read:
-        draft_stage_strategies = read_write.read_dictionary(path)
+        # The strategy dict is keyed by (friendly, enemy) integer-code tuples,
+        # which JSON can't use as object keys, so it is persisted as a list of
+        # [key, strategy] pairs (GitHub issue #13, B2). Tuple the keys on read.
+        serialised = read_write.read_dictionary(path)
+        if serialised is not None:
+            draft_stage_strategies = {tuple(key): strategy for key, strategy in serialised}
 
     if draft_stage_strategies is None:
         draft_stage_strategies = get_strategy_dictionary(ctx, gamestate_dictionary_to_solve, lower_level_strategies)
 
         if write:
-            read_write.write_dictionary(path, draft_stage_strategies)
+            read_write.write_dictionary(
+                path, [[list(key), strategy] for key, strategy in draft_stage_strategies.items()])
 
     ctx.strategy_dictionaries[strategy_dictionary_name].update(draft_stage_strategies)
 

--- a/drafter/tests/_solve_fixture.py
+++ b/drafter/tests/_solve_fixture.py
@@ -59,8 +59,8 @@ initial_strategy = utilities.get_arbitrary_dictionary_entry(initial_strategy_dic
 
 result = {
     "n": initial_n,
-    "friendly": [[entry[0], entry[1]] for entry in initial_strategy[0]],
-    "enemy": [[entry[0], entry[1]] for entry in initial_strategy[1]],
+    "friendly": [[ctx.friendly.name(entry[0]), entry[1]] for entry in initial_strategy[0]],
+    "enemy": [[ctx.enemy.name(entry[0]), entry[1]] for entry in initial_strategy[1]],
     "value": initial_strategy[2],
 }
 

--- a/drafter/tests/test_discard_wiring.py
+++ b/drafter/tests/test_discard_wiring.py
@@ -5,10 +5,11 @@ attackers to the child pools, not the attackers who just played. The golden
 tests would catch a regression only as an unexplained value shift; this test
 pins the wiring itself, cell by cell, with sentinel child values.
 
-In-process like test_map_model.py: a SolverContext is built with the test
-pairing tables and get_game_strategy is stubbed to capture the payoff matrix,
-so no solver or global state is involved.
+In-process (post-B2, GitHub issue #13): players are integer indices, pairing
+values are index-keyed numpy arrays on a SolverContext, and get_game_strategy
+is stubbed to capture the payoff matrix -- no solver or global state involved.
 """
+import numpy as np
 import pytest
 
 import drafter.common.utilities as utilities
@@ -21,9 +22,13 @@ from drafter.common.team_permutation import TeamPermutation
 
 
 def make_ctx(best, worst):
+    friendly = context.NameIndex.from_names(["f{}".format(i) for i in range(best.shape[0])])
+    enemy = context.NameIndex.from_names(["e{}".format(i) for i in range(best.shape[1])])
     return context.SolverContext(
         config=context.SolverConfig(),
         enemy_team_name="Test",
+        friendly=friendly,
+        enemy=enemy,
         pairing=PairingTables(best, worst, 0.5),
         restriction=None,
         gamestate_dictionaries={},
@@ -40,25 +45,23 @@ def child_key(remaining_friends, extra_friend, remaining_enemies, extra_enemy):
 
 
 def test_discard_attacker_returns_refused_attackers_to_child_pools(monkeypatch):
-    # 6-player state, mid-draft: defenders picked, attackers presented.
-    # Names chosen already-sorted so TeamPermutation's attacker sorting is a
-    # no-op and fA/eA keep their roles.
-    f_defender, f_attacker_A, f_attacker_B = "Fdef", "FattA", "FattB"
-    remaining_friends = ["Frem1", "Frem2", "Frem3"]
-    e_defender, e_attacker_A, e_attacker_B = "Edef", "EattA", "EattB"
-    remaining_enemies = ["Erem1", "Erem2", "Erem3"]
+    # 6-player state, mid-draft: defenders picked, attackers presented. Indices
+    # per side: defender 0, attacker_A 1, attacker_B 2, remaining 3/4/5.
+    f_defender, f_attacker_A, f_attacker_B = 0, 1, 2
+    remaining_friends = [3, 4, 5]
+    e_defender, e_attacker_A, e_attacker_B = 0, 1, 2
+    remaining_enemies = [3, 4, 5]
 
-    # Distinct pairing values so each fixed-pairing term is identifiable:
-    # the friendly defender defends (best map), the enemy defender forces the
-    # worst map. PairingTables.value reads both dictionaries for every pairing,
-    # so the side not selected is filled with a sentinel that would blow up
-    # the expected matrix if it ever leaked in.
-    best = {
-        f_defender: {e_attacker_A: 1.0, e_attacker_B: 2.0},
-        f_attacker_A: {e_defender: -99.0}, f_attacker_B: {e_defender: -99.0}}
-    worst = {
-        f_defender: {e_attacker_A: -99.0, e_attacker_B: -99.0},
-        f_attacker_A: {e_defender: 10.0}, f_attacker_B: {e_defender: 20.0}}
+    # Distinct pairing values so each fixed-pairing term is identifiable: the
+    # friendly defender defends (best map), the enemy defender forces the worst
+    # map. Every other cell is a sentinel that would blow up the expected matrix
+    # if the wrong map or pairing ever leaked in.
+    best = np.full((6, 6), -99.0)
+    worst = np.full((6, 6), -99.0)
+    best[f_defender, e_attacker_A] = 1.0
+    best[f_defender, e_attacker_B] = 2.0
+    worst[f_attacker_A, e_defender] = 10.0
+    worst[f_attacker_B, e_defender] = 20.0
     ctx = make_ctx(best, worst)
 
     # Sentinel child-game values, one per (returned friend, returned enemy).
@@ -86,9 +89,9 @@ def test_discard_attacker_returns_refused_attackers_to_child_pools(monkeypatch):
 
     assert games.discard_attacker(ctx, 6, gamestate, select_defender_strategies) == "stub"
 
-    # Row = enemy attacker the friendly side refuses, column = friendly
-    # attacker the enemy side refuses. In each cell the KEPT attackers play
-    # the defenders and the REFUSED pair is returned to the child pools.
+    # Row = enemy attacker the friendly side refuses, column = friendly attacker
+    # the enemy side refuses. In each cell the KEPT attackers play the defenders
+    # and the REFUSED pair is returned to the child pools.
     fD_eA, fD_eB = 1.0, 2.0
     fA_eD, fB_eD = 10.0, 20.0
     expected = [

--- a/drafter/tests/test_map_model.py
+++ b/drafter/tests/test_map_model.py
@@ -8,11 +8,12 @@ is either a pure function or restored via monkeypatch, and the golden tests
 solve in fresh subprocesses anyway (see conftest.py), so no state can leak
 into them.
 """
+import numpy as np
 import pytest
 
 import drafter.data.initialise_dictionaries as initialise_dictionaries
 import drafter.data.read_write as read_write
-from drafter.common.pairing import PairingTables
+from drafter.common.pairing import PairingTables, Defender
 
 
 # --- parse_rating: legacy tokens ---
@@ -66,26 +67,43 @@ def test_parse_rating_strips_whitespace_before_token_lookup(value, deviation):
 
 @pytest.fixture
 def small_pairing():
-    return PairingTables({"Alice": {"Ork": 6.0}}, {"Alice": {"Ork": 2.0}}, 0.5)
+    return PairingTables(np.array([[6.0]]), np.array([[2.0]]), 0.5)
 
 
 def test_pairing_value_friendly_defender_gets_best_map(small_pairing):
-    assert small_pairing.value("Alice", "Ork", defender="Alice") == 6.0
+    assert small_pairing.value(0, 0, Defender.FRIENDLY) == 6.0
 
 
 def test_pairing_value_enemy_defender_forces_worst_map(small_pairing):
-    assert small_pairing.value("Alice", "Ork", defender="Ork") == 2.0
+    assert small_pairing.value(0, 0, Defender.ENEMY) == 2.0
 
 
 def test_pairing_value_no_defender_uses_neutral_weight():
-    best, worst = {"Alice": {"Ork": 6.0}}, {"Alice": {"Ork": 2.0}}
-    assert PairingTables(best, worst, 0.5).value("Alice", "Ork") == 4.0
-    assert PairingTables(best, worst, 0.25).value("Alice", "Ork") == 3.0
+    best, worst = np.array([[6.0]]), np.array([[2.0]])
+    assert PairingTables(best, worst, 0.5).value(0, 0) == 4.0
+    assert PairingTables(best, worst, 0.25).value(0, 0) == 3.0
 
 
 def test_pairing_value_unknown_defender_raises(small_pairing):
     with pytest.raises(ValueError):
-        small_pairing.value("Alice", "Ork", defender="Bob")
+        small_pairing.value(0, 0, defender="Bob")
+
+
+def test_pairing_tables_from_dicts_maps_names_to_name_sorted_indices():
+    # Enemy CSV order (Ork, Chaos) differs from name-sorted (Chaos, Ork); the
+    # arrays must be laid out in name-sorted index order.
+    from drafter.solver.context import NameIndex
+    friendly = NameIndex.from_names(["Alice", "Bob"])
+    enemy = NameIndex.from_names(["Ork", "Chaos"])
+    best = {"Alice": {"Ork": 6.0, "Chaos": 5.0}, "Bob": {"Ork": 1.0, "Chaos": 2.0}}
+    worst = {"Alice": {"Ork": 3.0, "Chaos": 1.0}, "Bob": {"Ork": 0.0, "Chaos": 1.0}}
+
+    pairing = PairingTables.from_dicts(best, worst, friendly, enemy, 0.5)
+
+    # Chaos is enemy index 0, Ork index 1 (name-sorted); Alice 0, Bob 1.
+    assert pairing.value(0, 1, Defender.FRIENDLY) == 6.0   # Alice vs Ork, best
+    assert pairing.value(0, 0, Defender.FRIENDLY) == 5.0   # Alice vs Chaos, best
+    assert pairing.value(1, 0, Defender.ENEMY) == 1.0      # Bob vs Chaos, worst
 
 
 # --- validate_best_not_below_worst ---

--- a/drafter/tests/test_packing.py
+++ b/drafter/tests/test_packing.py
@@ -1,0 +1,72 @@
+"""Unit tests for the packed-integer team-permutation encoding (GitHub issue
+#13, B2). The encode/decode round-trip and injectivity are what make the packed
+int a drop-in replacement for the old string key: same dict semantics iff the
+mapping is a bijection over the reachable permutations.
+"""
+import itertools
+
+import pytest
+
+from drafter.common import packing
+from drafter.common.draft_stage import DraftStage
+
+
+def test_mask_round_trip():
+    for r in range(0, 4):
+        for indices in itertools.combinations(range(8), r):
+            mask = packing.mask_from_indices(indices)
+            assert packing.indices_from_mask(mask) == sorted(indices)
+
+
+def test_role_round_trip_including_none():
+    cases = [
+        (0b10110101, 0, 1, 2, 3),
+        (0b11111111, 7, None, None, None),
+        (0b00000000, None, None, None, None),
+        (0b00001111, 3, 0, 5, 0),
+        (0xFF, 6, 7, 4, 7),
+    ]
+    for remaining_mask, defender, attacker_a, attacker_b, discarded in cases:
+        code = packing.encode_team_permutation(remaining_mask, defender, attacker_a, attacker_b, discarded)
+        assert packing.decode_team_permutation(code) == (remaining_mask, defender, attacker_a, attacker_b, discarded)
+
+
+def test_code_fits_in_24_bits():
+    code = packing.encode_team_permutation(0xFF, 7, 7, 7, 7)
+    assert code < (1 << 24)
+
+
+def test_encoding_is_injective_over_a_broad_sample():
+    seen = {}
+    # Roles range over 0..7 and None (=ROLE_NONE); sample masks across the byte.
+    role_values = list(range(8)) + [None]
+    masks = list(range(0, 256, 7)) + [0, 255]
+    for remaining_mask in masks:
+        for defender in role_values:
+            for attacker_a in (None, 0, 3, 7):
+                for discarded in (None, 2, 5):
+                    key = (remaining_mask, defender, attacker_a, 1, discarded)
+                    code = packing.encode_team_permutation(*key)
+                    assert code not in seen or seen[code] == key, \
+                        "collision: {} and {} both -> {}".format(seen.get(code), key, code)
+                    seen[code] = key
+
+
+@pytest.mark.parametrize("defender,attacker_a,attacker_b,discarded,expected", [
+    (None, None, None, None, DraftStage.none),
+    (0, None, None, None, DraftStage.select_defender),
+    (0, 1, 2, None, DraftStage.select_attackers),
+    (0, 1, 2, 1, DraftStage.discard_attacker),
+])
+def test_draft_stage_of_code(defender, attacker_a, attacker_b, discarded, expected):
+    code = packing.encode_team_permutation(0b1100, defender, attacker_a, attacker_b, discarded)
+    assert packing.draft_stage_of_code(code) == expected
+
+
+def test_team_permutation_n_counts_remaining_plus_roles():
+    # 2 remaining + defender + 2 attackers = 5.
+    code = packing.encode_team_permutation(packing.mask_from_indices([6, 7]), 0, 1, 2, None)
+    assert packing.team_permutation_n(code) == 5
+    # 8 remaining, no roles set (the initial 8-player 'none' permutation).
+    code = packing.encode_team_permutation(packing.mask_from_indices(range(8)), None, None, None, None)
+    assert packing.team_permutation_n(code) == 8

--- a/scripts/compute_golden_value.py
+++ b/scripts/compute_golden_value.py
@@ -50,5 +50,7 @@ initial_strategy = utilities.get_arbitrary_dictionary_entry(initial_strategy_dic
 
 print("\nFixture: {}, k={}, n={}".format(fixture_name, k, initial_n))
 print("Top-level value (repr): {!r}".format(initial_strategy[2]))
-print("Friendly top-level strategy: {}".format(initial_strategy[0]))
-print("Enemy top-level strategy: {}".format(initial_strategy[1]))
+print("Friendly top-level strategy: {}".format(
+    [[ctx.friendly.name(entry[0]), entry[1]] for entry in initial_strategy[0]]))
+print("Enemy top-level strategy: {}".format(
+    [[ctx.enemy.name(entry[0]), entry[1]] for entry in initial_strategy[1]]))


### PR DESCRIPTION
Second of three PRs for **#13 (B2)** + **#26** (context → **integer keys** → user data dir). Builds on PR-A (#35). Part of #13.

Replaces the verbose string gamestate/team-permutation keys with **packed 24-bit integers**. The engine now works in name-sorted player indices; names live only at the presentation layer.

## What changed
- **`drafter/common/packing.py`**: a team permutation packs `(remaining bitmask | 4×4-bit role slots)` into one int; a gamestate key is the `(friendly, enemy)` code pair; draft stage is derived from the code. Property-tested in `test_packing.py` (round-trip, injectivity, `n`/stage agreement).
- **`PairingTables`** → index-keyed **numpy arrays** + a `Defender` enum (friendly-defends → best, enemy → worst, none → neutral midpoint).
- **`NameIndex`** (context.py) assigns indices in **name-sorted order** — deliberately matching the old string-key engine's ordering everywhere — so this is a pure relabelling: enumeration order, payoff matrices and equilibrium selection are unchanged.
- **`TeamPermutation`/`GameState`** hold indices; `get_key` packs, `get_..._from_key` decodes.
- **`draft.py`** maps indices↔names at the UI boundary (display, input matching, pairings); a discard-stage subtlety is handled: each team chooses among the *opponent's* attackers, so that choice space is the opponent's index space.
- **Cache format v5**: int-tuple keys serialised as `[f,e]` lists; strategy dicts as `[key, strategy]` pair lists (JSON can't key on tuples); the marker now records the player-name ordering and rejects a cache whose CSV names/order changed.

## Verification
- **Bit-identical values vs `main` (PR-A)** — verified by direct comparison: Smoke `4.997553182223154`, Six `1.9058104884743532` (both match `main` exactly). Scotland k=3 slow test passes (value + supports). Smoke draft output identical.
- Fast suite **80 passed** (adds packing + `from_dicts` tests); v5 cache round-trip verified (write→read bit-identical).
- **Enumeration phase 12.06 s** ≤ 16 s baseline. ✓

> Note: the golden pins (`...153`, `...512`) are 1–2 ulp off from what **both** `main` and this branch produce (`...154`, `...532`) — a pre-existing B1-LP-solver artifact covered by the tests' `abs=1e-9`. Not touched here; this PR changes nothing vs PR-A.

## RAM (acceptance criterion) — deferred to B3
Scotland k=3 peak working set is **~1816 MB** (baseline ~2 GB), which **misses the <200 MB target**. As PLAN.md anticipated, packed keys shrink the *keys*, but the ~1.5M `GameState` objects and ~950k strategy vectors stored as dict *values* dominate RAM; the <200 MB win requires **B3 (value-only backward induction)** — "kills the 271 MB strategy dictionaries". Per the agreed plan ("measure after B2, defer B3 if needed"), B3 is a separate follow-up. This PR lands the encoding foundation B3 builds on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)