### PR TITLE
B2c: per-user match & cache directories via platformdirs (#26)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,8 @@ drafter/
     pairing.py             PairingTables: defender-picks-the-map value lookups for one match
   data/
     initialise_dictionaries.py  reads CSVs (read_pairing_matrix), builds the SolverContext, solves
-    set_enemy_team.py      InquirerPy menu over drafter/resources/matches/<team>/ (returns the name)
+    paths.py               match-folder + cache resolution (platformdirs, issue #26)
+    set_enemy_team.py      InquirerPy menu over paths.list_available_teams() (returns the name)
     read_write.py          JSON cache IO
   solver/
     context.py             SolverConfig (the knobs) + SolverContext (all per-run state, passed explicitly)
@@ -45,12 +46,20 @@ drafter/
     games.py               build the payoff matrix for one gamestate from child values
     draft.py               interactive draft loop (uses plain input(), not InquirerPy)
     draft_loop.py          replay wrapper
-  resources/matches/<Team>/    one folder per opponent = the "database"
+  resources/matches/<Team>/    packaged read-only SAMPLE opponents (issue #26)
     pairing_matrix_best.csv    required input (see format below)
     pairing_matrix_worst.csv   required input
-    cache_format.json          cache version marker (see read_write.py)
-    *_dictionary.json          cached preprocessing output (gitignored, can be 100s of MB)
 ```
+
+Match folders resolve from a **per-user data dir first, packaged samples
+second** (`drafter/data/paths.py`, issue #26): a user's own opponents live in
+`platformdirs.user_data_dir("wtc-draft-solver")/matches/<Team>/`
+(`%APPDATA%\wtc-draft-solver\matches` on Windows), searched before the bundled
+samples under `drafter/resources/matches/`. Solver JSON caches
+(`cache_format.json`, `*_dictionary.json`) are written to the platform **cache**
+dir (`user_cache_dir(...)/matches/<Team>/`), never into the package — so a
+pip/pipx install stays clean. `ctx.paths` (a `MatchPaths`) carries `input_dir`
+and `cache_dir` for the current match.
 
 ## How it works (important for any performance work)
 
@@ -182,7 +191,8 @@ Notes for agents:
   test needs `-m slow`, ~5 min). CI (`.github/workflows/ci.yml`) runs the
   smoke test + fast suite on every push/PR — keep it green; run `pytest`
   before pushing solver changes.
-- JSON caches under `drafter/resources/matches/` are gitignored; never commit
-  them. Never commit `.venv/` or `__pycache__/`.
+- Solver JSON caches now live in the platform cache dir (issue #26), not the
+  repo; any stray `*.json` under `drafter/resources/matches/` is gitignored —
+  never commit caches, `.venv/`, or `__pycache__/`.
 - PLAN.md holds the current revival roadmap (performance, 11th-edition map
   rules, web distribution). Read it before starting substantial work.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,21 @@ matchup (10–10). Best must be ≥ worst in every cell.
 Folders in the old single-matrix format can be converted with
 `python scripts/migrate_match_folder.py drafter/resources/matches/<Team>`.
 
+### Where match folders live
+
+The bundled `drafter/resources/matches/<Team>/` folders are **read-only
+samples**. Put your own opponents in a per-user data directory, which is
+searched first (so they survive package upgrades and work with `pipx`
+installs):
+
+- **Windows:** `%APPDATA%\wtc-draft-solver\matches\<Team>\`
+- **macOS:** `~/Library/Application Support/wtc-draft-solver/matches/<Team>/`
+- **Linux:** `~/.local/share/wtc-draft-solver/matches/<Team>/`
+
+Each folder holds the two CSVs above. Solver caches are written to the platform
+cache directory (e.g. `%LOCALAPPDATA%\wtc-draft-solver\Cache\matches\` on
+Windows), never into the installed package.
+
 ## Local setup
 
 ### Prerequisites

--- a/drafter/common/utilities.py
+++ b/drafter/common/utilities.py
@@ -1,5 +1,3 @@
-from pathlib import Path  # standard libraries
-
 import numpy as np  # 3rd party packages
 from scipy.optimize import linprog
 
@@ -187,18 +185,6 @@ def print_overview(game_overview, roundTo=3):
     print("Row strategy: ", round_row_strategy)
     print("Column strategy: ", round_column_strategy)
     print("Value: ", round_value)
-
-
-def get_path(enemy_team_name, filename):
-    drafter_path = Path(__file__).parent.parent
-
-    if enemy_team_name is None:
-        path = drafter_path / (filename)
-    else:
-        subfolder = "resources/matches/" + enemy_team_name
-        path = drafter_path / (subfolder + "/" + filename)
-
-    return path
 
 
 def get_empty_matrix(n, m):

--- a/drafter/data/initialise_dictionaries.py
+++ b/drafter/data/initialise_dictionaries.py
@@ -1,10 +1,10 @@
 import time  # standard libraries
 import csv
 
-import drafter.common.utilities as utilities  # local source
-import drafter.common.team_permutation as team_permutation
+import drafter.common.team_permutation as team_permutation  # local source
 from drafter.common.pairing import PairingTables
 import drafter.data.read_write as read_write
+import drafter.data.paths as paths
 import drafter.solver.context as context
 import drafter.solver.games as games
 import drafter.solver.strategy_dictionaries as strategy_dictionaries
@@ -15,10 +15,12 @@ def initialise(enemy_team_name, config):
     """Load a match's input matrices, build the SolverContext, and solve the
     whole draft tree into it. Returns the populated SolverContext (GitHub issue
     #13, B2 solver-context refactor: no module-level globals)."""
+    match_paths = paths.resolve_match(enemy_team_name)
+
     best = read_pairing_matrix(
-        utilities.get_path(enemy_team_name, "pairing_matrix_best.csv"), config.require_unique_names)
+        match_paths.input_file("pairing_matrix_best.csv"), config.require_unique_names)
     worst = read_pairing_matrix(
-        utilities.get_path(enemy_team_name, "pairing_matrix_worst.csv"), config.require_unique_names)
+        match_paths.input_file("pairing_matrix_worst.csv"), config.require_unique_names)
     validate_best_not_below_worst(best, worst)
 
     # Assign player indices in name-sorted order (see context.NameIndex): enemy
@@ -38,6 +40,7 @@ def initialise(enemy_team_name, config):
         enemy=enemy,
         pairing=pairing,
         restriction=restriction,
+        paths=match_paths,
         gamestate_dictionaries=game_state_dictionaries.make_gamestate_dictionaries(),
         strategy_dictionaries=strategy_dictionaries.make_strategy_dictionaries(),
         game_solution_caches=games.make_game_solution_caches())
@@ -51,7 +54,7 @@ def initialise(enemy_team_name, config):
     # the current engine and the current name ordering; the marker is written
     # after a successful solve+write below.
     caches_are_current = read_write.cache_format_is_current(
-        utilities.get_path(enemy_team_name, read_write.CACHE_FORMAT_FILENAME), friendly_names, enemy_names)
+        match_paths.cache_file(read_write.CACHE_FORMAT_FILENAME), friendly_names, enemy_names)
     if (config.read_gamestates or config.read_strategies) and not caches_are_current:
         print("Ignoring cached JSONs in this match folder (missing or outdated {}): "
             "they were computed under an older value model. Solving fresh."
@@ -81,7 +84,7 @@ def initialise(enemy_team_name, config):
 
     if config.write_gamestates and config.write_strategies:
         read_write.write_cache_format_marker(
-            utilities.get_path(enemy_team_name, read_write.CACHE_FORMAT_FILENAME), friendly_names, enemy_names)
+            match_paths.cache_file(read_write.CACHE_FORMAT_FILENAME), friendly_names, enemy_names)
 
     return ctx
 

--- a/drafter/data/paths.py
+++ b/drafter/data/paths.py
@@ -1,0 +1,63 @@
+"""Match-folder and cache path resolution (GitHub issue #26).
+
+A pip/pipx-installed user can't edit match folders inside site-packages (they're
+undiscoverable and wiped on upgrade), and solver caches shouldn't be written
+there either. So match inputs resolve from a per-user data directory searched
+BEFORE the packaged samples, and caches go to the platform cache directory. The
+packaged folders under drafter/resources/matches stay read-only samples.
+"""
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import platformdirs
+
+APP_NAME = "wtc-draft-solver"
+
+
+def packaged_matches_dir():
+    # Bundled read-only sample match folders shipped inside the package.
+    return Path(__file__).resolve().parent.parent / "resources" / "matches"
+
+
+def user_matches_dir():
+    # Per-user match folders (%APPDATA%\wtc-draft-solver\matches on Windows),
+    # searched before the packaged samples so installed users can add their own.
+    return Path(platformdirs.user_data_dir(APP_NAME, appauthor=False, roaming=True)) / "matches"
+
+
+def user_cache_root():
+    # Solver JSON caches go to the platform cache dir, never into site-packages.
+    return Path(platformdirs.user_cache_dir(APP_NAME, appauthor=False)) / "matches"
+
+
+@dataclass(frozen=True)
+class MatchPaths:
+    input_dir: Path       # where this match's CSVs are read from
+    cache_dir: Path       # where this match's solver caches are written
+
+    def input_file(self, filename):
+        return self.input_dir / filename
+
+    def cache_file(self, filename):
+        return self.cache_dir / filename
+
+
+def resolve_match(team):
+    """Input CSVs from the user's matches dir if that team folder exists there,
+    else from the packaged samples; caches always in the user cache dir."""
+    user_dir = user_matches_dir() / team
+    input_dir = user_dir if user_dir.is_dir() else packaged_matches_dir() / team
+    return MatchPaths(input_dir=input_dir, cache_dir=user_cache_root() / team)
+
+
+def list_available_teams():
+    """Team folder names from the user matches dir and the packaged samples,
+    deduped (a user folder shadows a packaged sample of the same name)."""
+    teams = set()
+    for source in (user_matches_dir(), packaged_matches_dir()):
+        if source.is_dir():
+            for entry in os.listdir(source):
+                if (source / entry).is_dir():
+                    teams.add(entry)
+    return sorted(teams)

--- a/drafter/data/read_write.py
+++ b/drafter/data/read_write.py
@@ -38,6 +38,7 @@ def write_cache_format_marker(path, friendly_names=None, enemy_names=None):
     if friendly_names is not None:
         marker["friendly_names"] = list(friendly_names)
         marker["enemy_names"] = list(enemy_names)
+    path.parent.mkdir(parents=True, exist_ok=True)
     with path.open('w', encoding='utf-8') as f:
         json.dump(marker, f)
 
@@ -55,6 +56,7 @@ def read_dictionary(path):
 
 
 def write_dictionary(path, dictionary):
+    path.parent.mkdir(parents=True, exist_ok=True)
     with path.open('w', encoding='utf-8') as f:
         print("   Writing file {} ...".format(path))
         json.dump(dictionary, f, ensure_ascii=False, indent=4)

--- a/drafter/data/set_enemy_team.py
+++ b/drafter/data/set_enemy_team.py
@@ -1,13 +1,10 @@
-import os  # standard libraries
-from pathlib import Path
-from InquirerPy import inquirer
+from InquirerPy import inquirer  # 3rd party packages
+
+import drafter.data.paths as paths  # local source
 
 
 def prompt_enemy_team():
-    source_path = Path(__file__).parent.parent
-    matches_path = source_path / "resources/matches"
-    teams = os.listdir(matches_path)
-    if "matches" in teams: teams.remove("matches")
+    teams = paths.list_available_teams()
 
     enemy_team_name = inquirer.select(
         message="Select enemy team:",

--- a/drafter/solver/context.py
+++ b/drafter/solver/context.py
@@ -70,6 +70,7 @@ class SolverContext:
     enemy: NameIndex                  # index <-> name for the enemy team
     pairing: Any                      # drafter.common.pairing.PairingTables
     restriction: Any                  # team_permutation.RestrictionData | None
+    paths: Any                        # drafter.data.paths.MatchPaths
     gamestate_dictionaries: dict
     strategy_dictionaries: dict
     game_solution_caches: dict

--- a/drafter/solver/game_state_dictionaries.py
+++ b/drafter/solver/game_state_dictionaries.py
@@ -42,7 +42,7 @@ def initialise_dictionaries(ctx, read, write):
 
 def read_dictionaries(ctx):
     for name in global_gamestate_dictionary_names:
-        path = utilities.get_path(ctx.enemy_team_name, name + ".json")
+        path = ctx.paths.cache_file(name + ".json")
         key_list = read_write.read_dictionary(path)
 
         if (key_list is not None and len(key_list) > 0):
@@ -58,7 +58,7 @@ def read_dictionaries(ctx):
 
 def write_dictionaries(ctx):
     for name in global_gamestate_dictionary_names:
-        path = utilities.get_path(ctx.enemy_team_name, name + ".json")
+        path = ctx.paths.cache_file(name + ".json")
         # The (friendly, enemy) integer-code tuples serialise to JSON as lists.
         key_list = [key for key in ctx.gamestate_dictionaries[name]]
         read_write.write_dictionary(path, key_list)

--- a/drafter/solver/strategy_dictionaries.py
+++ b/drafter/solver/strategy_dictionaries.py
@@ -60,7 +60,7 @@ def update_dictionaries(ctx, read, write, gamestate_dictionaries):
 def process_gamestate_dictionary(ctx, read, write, gamestate_dictionary_to_solve, lower_level_strategies=None):
     arbitrary_gamestate = utilities.get_arbitrary_dictionary_entry(gamestate_dictionary_to_solve)
     strategy_dictionary_name = arbitrary_gamestate.get_strategy_dictionary_name()
-    path = utilities.get_path(ctx.enemy_team_name, strategy_dictionary_name + ".json")
+    path = ctx.paths.cache_file(strategy_dictionary_name + ".json")
 
     draft_stage_strategies = None
 

--- a/drafter/tests/conftest.py
+++ b/drafter/tests/conftest.py
@@ -15,8 +15,21 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
+import drafter.data.paths as paths
+
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 SOLVE_FIXTURE_SCRIPT = Path(__file__).resolve().parent / "_solve_fixture.py"
+
+
+@pytest.fixture(autouse=True)
+def isolate_user_cache_dir(monkeypatch, tmp_path):
+    """Keep every in-process test off the real platform cache dir (issue #26):
+    redirect the solver cache root to a per-test temp dir. Tests that need a
+    specific location override this with their own monkeypatch. (Golden tests run
+    in subprocesses and disable cache I/O, so they are unaffected either way.)"""
+    monkeypatch.setattr(paths, "user_cache_root", lambda: tmp_path / "solver-cache")
 
 
 def solve_fixture(fixture_name, k, timeout=None):

--- a/drafter/tests/test_discard_wiring.py
+++ b/drafter/tests/test_discard_wiring.py
@@ -31,6 +31,7 @@ def make_ctx(best, worst):
         enemy=enemy,
         pairing=PairingTables(best, worst, 0.5),
         restriction=None,
+        paths=None,
         gamestate_dictionaries={},
         strategy_dictionaries={},
         game_solution_caches=games.make_game_solution_caches())

--- a/drafter/tests/test_paths.py
+++ b/drafter/tests/test_paths.py
@@ -1,0 +1,70 @@
+"""Tests for per-user match/cache path resolution (GitHub issue #26): a
+pip/pipx user's own match folders (in the platform data dir) are searched before
+the packaged samples, and solver caches go to the platform cache dir instead of
+site-packages. Packaged folders stay read-only samples.
+
+In-process: paths.user_matches_dir / user_cache_root are monkeypatched to
+tmp_path, so nothing touches the real user directories.
+"""
+from pathlib import Path
+
+import drafter.data.paths as paths
+import drafter.data.read_write as read_write
+
+
+def test_resolve_match_falls_back_to_packaged(monkeypatch, tmp_path):
+    monkeypatch.setattr(paths, "user_matches_dir", lambda: tmp_path / "user" / "matches")
+    monkeypatch.setattr(paths, "user_cache_root", lambda: tmp_path / "cache")
+
+    match_paths = paths.resolve_match("Smoke")
+
+    # No user "Smoke" folder -> input resolves to the packaged sample.
+    assert match_paths.input_dir == paths.packaged_matches_dir() / "Smoke"
+    assert match_paths.input_file("pairing_matrix_best.csv").is_file()
+    # Cache always goes to the (writable) user cache dir, never the package.
+    assert match_paths.cache_dir == tmp_path / "cache" / "Smoke"
+
+
+def test_resolve_match_prefers_user_dir(monkeypatch, tmp_path):
+    user = tmp_path / "user" / "matches"
+    (user / "MyTeam").mkdir(parents=True)
+    monkeypatch.setattr(paths, "user_matches_dir", lambda: user)
+    monkeypatch.setattr(paths, "user_cache_root", lambda: tmp_path / "cache")
+
+    match_paths = paths.resolve_match("MyTeam")
+
+    assert match_paths.input_dir == user / "MyTeam"
+
+
+def test_list_available_teams_unions_and_dedupes(monkeypatch, tmp_path):
+    user = tmp_path / "user" / "matches"
+    (user / "UserOnly").mkdir(parents=True)
+    (user / "Smoke").mkdir()  # same name as a packaged sample -> deduped
+    monkeypatch.setattr(paths, "user_matches_dir", lambda: user)
+
+    teams = paths.list_available_teams()
+
+    assert "UserOnly" in teams          # from the user dir
+    assert "Scotland" in teams          # from the packaged samples
+    assert teams.count("Smoke") == 1    # user folder shadows the packaged one
+    assert teams == sorted(teams)
+
+
+def test_list_available_teams_without_user_dir(monkeypatch, tmp_path):
+    monkeypatch.setattr(paths, "user_matches_dir", lambda: tmp_path / "absent")
+
+    teams = paths.list_available_teams()
+
+    assert "Smoke" in teams  # packaged samples still listed when no user dir
+
+
+def test_match_paths_join():
+    match_paths = paths.MatchPaths(input_dir=Path("in"), cache_dir=Path("cache"))
+    assert match_paths.input_file("x.csv") == Path("in") / "x.csv"
+    assert match_paths.cache_file("y.json") == Path("cache") / "y.json"
+
+
+def test_write_dictionary_creates_missing_cache_dir(tmp_path):
+    target = tmp_path / "fresh" / "nested" / "gamestate.json"
+    read_write.write_dictionary(target, [[1, 2], [3, 4]])
+    assert target.is_file()

--- a/drafter/tests/test_paths.py
+++ b/drafter/tests/test_paths.py
@@ -25,6 +25,18 @@ def test_resolve_match_falls_back_to_packaged(monkeypatch, tmp_path):
     assert match_paths.cache_dir == tmp_path / "cache" / "Smoke"
 
 
+def test_resolve_match_falls_back_when_user_dir_lacks_team(monkeypatch, tmp_path):
+    # The user matches dir exists but has no folder for this team -> packaged.
+    user = tmp_path / "user" / "matches"
+    (user / "SomeOtherTeam").mkdir(parents=True)
+    monkeypatch.setattr(paths, "user_matches_dir", lambda: user)
+    monkeypatch.setattr(paths, "user_cache_root", lambda: tmp_path / "cache")
+
+    match_paths = paths.resolve_match("Smoke")
+
+    assert match_paths.input_dir == paths.packaged_matches_dir() / "Smoke"
+
+
 def test_resolve_match_prefers_user_dir(monkeypatch, tmp_path):
     user = tmp_path / "user" / "matches"
     (user / "MyTeam").mkdir(parents=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "inquirerpy==0.3.4",
     "loguru==0.7.2",
     "numpy==2.0.0",
+    "platformdirs==4.10.0",
     "pfzy==0.3.4",
     "prompt_toolkit==3.0.47",
     "scipy==1.14.0",


### PR DESCRIPTION
Third of three PRs for **#13 (B2)** + **#26** (context → integer keys → **user data dir**). Builds on PR-A (#35) and PR-B (#36). Closes #26.

Today a pip/pipx user can only draft against the bundled sample matrices: `get_path` resolved match folders **and** wrote 100s-of-MB caches inside the installed package (site-packages) — undiscoverable and wiped on upgrade.

## What changed
- **`drafter/data/paths.py`**: match inputs resolve from a **per-user data dir first, packaged samples second** (`platformdirs.user_data_dir` → `%APPDATA%\wtc-draft-solver\matches` on Windows); solver caches go to the **platform cache dir** (`user_cache_dir`), created on demand. `MatchPaths(input_dir, cache_dir)` is carried on the `SolverContext` (`ctx.paths`).
- **`set_enemy_team`** lists `paths.list_available_teams()` — user + packaged, deduped (a user folder shadows a sample of the same name).
- `initialise` / `game_state_dictionaries` / `strategy_dictionaries` read+write via `ctx.paths.input_file` / `cache_file`; `read_write` write helpers `mkdir` the cache dir.
- Removed the now-unused `utilities.get_path` (and its `Path` import). Packaged `drafter/resources/matches/` folders are read-only samples.
- `platformdirs==4.10.0` added to `pyproject.toml` (packaging already ships only CSVs, so caches never enter the wheel).

## Verification
- Golden tests fall back to the packaged samples (no user dir set), so values are **unchanged** — fast suite **86 passed** (adds `test_paths.py`: packaged fallback, user-first, dedup, cache-dir auto-create), smoke draft output identical.
- Verified a real **write→read cache round-trip in the platform cache dir** (`%LOCALAPPDATA%\wtc-draft-solver\Cache\matches\Smoke`): 15 files written, dir auto-created, value bit-identical, cleaned up.
- Docs updated (README: where to put your own match folders per-OS; CLAUDE.md: paths.py + cache location).

🤖 Generated with [Claude Code](https://claude.com/claude-code)