### PR TITLE
Re-pin Smoke/Six golden values to exact current repr

### DIFF
--- a/drafter/tests/test_golden_values.py
+++ b/drafter/tests/test_golden_values.py
@@ -60,7 +60,11 @@ from drafter.tests.conftest import solve_fixture, strategy_probabilities, suppor
 # closed-form endgame. Re-verified 3x bit-identical.
 
 SMOKE_K = 4
-SMOKE_EXPECTED_VALUE = 4.997553182223153
+# Exact repr of the current engine's value (was 4.997553182223153, 1 ulp off:
+# the B1 LP solver shifted the last bit but the pin was only re-verified at the
+# 1e-9 tolerance below, not bit-exactly). Cross-platform float noise keeps the
+# tolerance; the literal now matches a fresh solve.
+SMOKE_EXPECTED_VALUE = 4.997553182223154
 SMOKE_EXPECTED_FRIENDLY_PROBS = [0.293, 0.0, 0.691, 0.015]  # Alice, Bob, Carol, Dave
 SMOKE_EXPECTED_ENEMY_PROBS = [0.047, 0.0, 0.513, 0.439]  # Chaos, Eldar, Ork, Tau
 
@@ -103,7 +107,9 @@ def test_smoke_4_player_top_level_strategies():
 # (issues #9/#30, encoding the pre-#32 child-key bug).
 
 SIX_K = 4
-SIX_EXPECTED_VALUE = 1.9058104884743512
+# Exact repr of the current engine's value (was 1.9058104884743512, 2 ulp off
+# for the same B1-LP reason as SMOKE above); tolerance kept for cross-platform.
+SIX_EXPECTED_VALUE = 1.9058104884743532
 
 
 def test_six_player_top_level_value():


### PR DESCRIPTION
Tiny follow-up. The Smoke and Six golden-value pins were 1–2 ulp stale versus what the engine actually produces:

| fixture | old pin | fresh solve (this run, = `main`) |
|---|---|---|
| Smoke | `4.997553182223153` | `4.997553182223154` |
| Six | `1.9058104884743512` | `1.9058104884743532` |

This is a **pre-existing B1 (scipy-LP solver) artifact** — the pins were only re-verified at the `abs=1e-9` tolerance, not bit-exactly — not anything from the B2 PRs (both B2 PRs were verified bit-identical to `main`). Scotland's pin was already exact and is unchanged.

Only the two literals change; the `abs=1e-9` tolerances stay (CI runs on Linux, dev on Windows — bit-exact `==` across BLAS builds isn't guaranteed). No engine change. `pytest drafter/tests/test_golden_values.py` → 3 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)