### PR TITLE
B3: value-only backward induction, ~120 MB at Scotland k=3 (#13)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,11 +38,11 @@ drafter/
     initialise_dictionaries.py  reads CSVs (read_pairing_matrix), builds the SolverContext, solves
     paths.py               match-folder + cache resolution (platformdirs, issue #26)
     set_enemy_team.py      InquirerPy menu over paths.list_available_teams() (returns the name)
-    read_write.py          JSON cache IO
+    read_write.py          JSON IO (used only by scripts/migrate_match_folder.py now)
   solver/
     context.py             SolverConfig (the knobs) + SolverContext (all per-run state, passed explicitly)
-    game_state_dictionaries.py  enumerate all reachable gamestates per (n, stage)
-    strategy_dictionaries.py    backward induction: solve every gamestate's game, deepest first
+    game_state_dictionaries.py  enumerate reachable gamestate keys per (n, stage) -> numpy int64 arrays
+    strategy_dictionaries.py    value-only backward induction; StageValues + draft strategy recompute (B3)
     games.py               build the payoff matrix for one gamestate from child values
     draft.py               interactive draft loop (uses plain input(), not InquirerPy)
     draft_loop.py          replay wrapper
@@ -55,33 +55,35 @@ Match folders resolve from a **per-user data dir first, packaged samples
 second** (`drafter/data/paths.py`, issue #26): a user's own opponents live in
 `platformdirs.user_data_dir("wtc-draft-solver")/matches/<Team>/`
 (`%APPDATA%\wtc-draft-solver\matches` on Windows), searched before the bundled
-samples under `drafter/resources/matches/`. Solver JSON caches
-(`cache_format.json`, `*_dictionary.json`) are written to the platform **cache**
-dir (`user_cache_dir(...)/matches/<Team>/`), never into the package — so a
-pip/pipx install stays clean. `ctx.paths` (a `MatchPaths`) carries `input_dir`
-and `cache_dir` for the current match.
+samples under `drafter/resources/matches/`. `ctx.paths` (a `MatchPaths`) carries
+the resolved `input_dir`. There is **no disk cache** (B3, issue #13): the solve
+is fast and low-RAM and is held in-process for the whole draft session.
 
 ## How it works (important for any performance work)
 
-1. **Gamestate enumeration** (`game_state_dictionaries`): starting from the
-   full 8v8 state, breadth-first enumerate every reachable `GameState` for
-   each (n ∈ {8,6,4}, stage) pair. States are stored in dicts keyed by
-   verbose human-readable strings (`"{Defender: X}, {Attacker A: Y}, ..."`).
-2. **Strategy solving** (`strategy_dictionaries`): iterate stages deepest
-   first (4-player select_attackers up to 8-player none). For each gamestate
-   build the payoff matrix whose entries are the already-solved values of
-   child states (`games.py`), then solve that matrix game **directly as the
-   zero-sum game it is** (`utilities.get_game_solution`, PLAN.md B1): a pure
-   saddle point when one exists, otherwise a 2x2 closed form, otherwise one
-   `scipy.optimize.linprog` (HiGHS) call whose dual yields the opposing
-   strategy. Deterministic, no degenerate-game warnings. Solutions are cached
-   by matrix hash — both bit-identical (per-stage caches in `games.py`) and
-   translation-normalised (`utilities.normalised_game_solution_cache`, since
-   zero-sum strategies/value are invariant under adding a constant). The
-   4-player discard endgame is closed-form.
-3. **Draft loop** (`draft.py`): walks the solved tree interactively. If the
-   user makes a move outside the enumerated tree (possible with k-restriction),
-   the tree is extended and re-solved on the fly.
+1. **Gamestate enumeration** (`game_state_dictionaries.enumerate_gamestates`):
+   breadth-first from the full 8v8 state, storing each (n ∈ {8,6,4}, stage)
+   level as a **sorted numpy int64 array of packed gamestate keys** — no
+   `GameState` objects are kept (they're decoded from keys on demand), so the
+   whole tree costs ~12 MB. A key is one int: friendly team code + enemy team
+   code (`drafter/common/packing.py`).
+2. **Value-only backward induction** (`strategy_dictionaries.initialise_values`,
+   B3): iterate the stages deepest first; for each gamestate build the payoff
+   matrix from its children's already-solved values (`games.build_game`) and
+   solve **directly as the zero-sum game it is** for the VALUE only
+   (`utilities.get_game_value` → `get_game_solution`, PLAN.md B1: saddle / 2x2
+   closed form / one HiGHS LP whose dual yields the opposing strategy). Values
+   are stored per stage as parallel sorted `(keys, values)` numpy arrays
+   (`StageValues`, binary-search lookup) — ~8 MB, not the ~810 MB of full
+   strategy vectors. Only the LP solves are memoised
+   (`utilities.normalised_game_solution_cache`). The 4-player discard endgame is
+   closed-form.
+3. **Draft loop** (`draft.py`): walks the solved tree interactively,
+   **recomputing** the labelled mixed strategy for each visited gamestate on
+   demand from its children's values (`strategy_dictionaries.game_strategy`).
+   The same recursion (`game_value`) transparently solves any off-tree,
+   non-k-restricted subtree the user navigates into — no separate tree
+   extension.
 
 Values are read through `ctx.pairing.value(friend, enemy, defender)`
 (a `PairingTables`, drafter/common/pairing.py): the best-map value when the
@@ -99,10 +101,13 @@ best when neither does (refused-vs-refused and last-players games).
   This cut the Scotland k=3 strategy phase from ~275 s to ~29 s (≈9×) with
   bit-stable golden values and no warnings. The remaining strategy-phase cost
   is now split between the ~35k genuinely-mixed LP solves (scipy's per-call
-  wrapper overhead dominates for these tiny games) and the string-keyed
-  gamestate iteration — the latter is what B2 (integer state encoding) targets.
-- Cached JSON for one 8-player opponent ≈ 630 MB (strategy dicts dominate);
-  loading that cache takes ~19 s. String keys are a large share of the RAM.
+  wrapper overhead dominates for these tiny games) and gamestate iteration.
+- **B2 (done, issue #13):** packed-integer gamestate keys + an explicit
+  `SolverContext` replaced the verbose string keys and module globals.
+- **B3 (done, issue #13):** value-only backward induction with numpy key/value
+  arrays (above) cut Scotland k=3 **peak RAM from ~1.8 GB to ~120 MB** (~15×);
+  fresh solve ≈ 28 s (enumeration ~8 s, values ~20 s). The old 630 MB JSON disk
+  cache is gone — the in-memory solve is fast and cheap enough not to need it.
 - `restricted_attackers_count` (k) in `SolverConfig` (drafter/solver/context.py) is the only current knob:
   each select-attackers step only considers the k heuristically best
   attackers per side (heuristic: advantage vs defender minus average vs

--- a/drafter/common/game_state.py
+++ b/drafter/common/game_state.py
@@ -1,6 +1,7 @@
 import drafter.common.utilities as utilities  # local source
 import drafter.common.team_permutation as team_permutation
 import drafter.common.draft_stage as draft_stage
+import drafter.common.packing as packing
 
 class GameState:
     def __init__(self, draft_stage, friendly_team_permutation, enemy_team_permutation):
@@ -9,10 +10,11 @@ class GameState:
         self.enemy_team_permutation = enemy_team_permutation
 
     def get_key(self):
-        # A gamestate key is the pair of packed-integer team-permutation codes
-        # (GitHub issue #13, B2). Hashable and compact; names are resolved only
-        # at the presentation layer.
-        return (self.friendly_team_permutation.get_key(), self.enemy_team_permutation.get_key())
+        # A gamestate key is a single packed integer combining the friendly and
+        # enemy team-permutation codes (issue #13; single-int form for numpy
+        # storage, B3). Names are resolved only at the presentation layer.
+        return packing.encode_gamestate(
+            self.friendly_team_permutation.get_key(), self.enemy_team_permutation.get_key())
 
     def get_n(self):
         friendly_n = self.friendly_team_permutation.get_n()
@@ -22,18 +24,6 @@ class GameState:
             raise ValueError("Inconsistent number of players.")
 
         return friendly_n
-
-    def get_gamestate_dictionary_name(self):
-        n = self.get_n()
-        gamestate_dictionary_name = utilities.get_gamestate_dictionary_name(n, self.draft_stage)
-        return gamestate_dictionary_name
-
-    # Returns the name of the draft iteration that follows this gamestate.
-    def get_strategy_dictionary_name(self):
-        n = self.get_n()
-        draft_stage_to_solve = draft_stage.get_next_draft_stage(self.draft_stage)
-        strategy_dictionary_name = utilities.get_strategy_dictionary_name(n, draft_stage_to_solve)
-        return strategy_dictionary_name
 
 
 def get_next_gamestates(ctx, game_permutation):
@@ -69,7 +59,7 @@ def get_next_gamestate_matrix(ctx, gamestate):
 
 
 def get_gamestate_from_key(key):
-    friendly_code, enemy_code = key
+    friendly_code, enemy_code = packing.decode_gamestate(key)
     friendly_team_permutation = team_permutation.get_team_permutation_from_key(friendly_code)
     enemy_team_permutation = team_permutation.get_team_permutation_from_key(enemy_code)
     draft_stage = friendly_team_permutation.get_draft_stage()

--- a/drafter/common/packing.py
+++ b/drafter/common/packing.py
@@ -10,9 +10,11 @@ A team permutation over <=8 players packs into a 24-bit int:
     bits 20..23 : discarded_attacker (4 bits)
 
 Indices are per side (friendly = CSV rows, enemy = CSV columns), 0..n-1. A
-gamestate key is the pair (friendly_code, enemy_code); the draft stage is
-derivable from either code (see draft_stage_of_code). Names live only in the
-presentation layer (drafter.solver.context NameIndex).
+gamestate key is a single int: the friendly team code in the low 24 bits and the
+enemy team code in the next 24 (so it fits a numpy int64 and packs the whole
+state into one hashable/array-able value, B3). The draft stage is derivable from
+either code (see draft_stage_of_code). Names live only in the presentation layer
+(drafter.solver.context NameIndex).
 """
 from drafter.common.draft_stage import DraftStage
 
@@ -24,6 +26,18 @@ _ATTACKER_B_SHIFT = 16
 _DISCARDED_SHIFT = 20
 _ROLE_MASK = 0xF
 _REMAINING_MASK = 0xFF
+
+# A team code occupies 24 bits; the gamestate key stacks enemy above friendly.
+_TEAM_BITS = 24
+_TEAM_MASK = (1 << _TEAM_BITS) - 1
+
+
+def encode_gamestate(friendly_code, enemy_code):
+    return friendly_code | (enemy_code << _TEAM_BITS)
+
+
+def decode_gamestate(key):
+    return (key & _TEAM_MASK, key >> _TEAM_BITS)
 
 
 def _pack_role(index):

--- a/drafter/common/utilities.py
+++ b/drafter/common/utilities.py
@@ -108,8 +108,8 @@ normalised_game_solution_cache = {}
 # -- so one solve yields both sides; no need for the symmetric second LP. The
 # shift is undone on the value. This is the formulation the independent oracle
 # (scripts/brute_force_oracle.py) uses to cross-check golden values. Only the
-# value propagates up the tree (games.get_game_array); the strategies are read
-# solely by the interactive draft loop.
+# value propagates up the tree (get_game_value); the strategies are read solely
+# by the interactive draft loop (get_game_strategy).
 def solve_zero_sum_game_by_linear_program(a):
     shift = a.min()
     positive_a = a - shift + 1.0
@@ -148,6 +148,18 @@ def solve_positivity_shifted_matrix_game(positive_a):
     column_strategy = list(np.abs(result.ineqlin.marginals) * shifted_value)
 
     return [row_strategy, column_strategy, shifted_value]
+
+
+# Value-only game solve for the backward induction (GitHub issue #13, B3): the
+# tree only propagates game VALUES, so skip building/labelling the mixed-strategy
+# vectors (the draft loop recomputes those on demand for the ~20 states it
+# visits). Deliberately not memoised per matrix: caching every one of the ~950k
+# small games would cost ~70 MB of peak RAM (the whole point of B3 is to keep RAM
+# down), while re-solving them is cheap -- 2x2 games are closed form and the
+# larger LP solves are still deduped by the translation-normalised cache inside
+# solve_zero_sum_game_by_linear_program.
+def get_game_value(game_array):
+    return get_game_solution(game_array)[2]
 
 
 def get_game_strategy(game_solution_cache, game_array, friendly_team_options, enemy_team_options):
@@ -211,33 +223,3 @@ def list_to_string(input_list):
     output_string += input_list[len(input_list) - 1]
 
     return output_string
-
-
-def get_gamestate_dictionary_name(n, draft_stage):
-    return get_dictionary_name(n, draft_stage, "gamestate")
-
-
-def get_strategy_dictionary_name(n, draft_stage):
-    return get_dictionary_name(n, draft_stage, "strategy")
-
-
-def get_dictionary_name(n, draft_stage, dictionary_type):
-    if not (n == 4 or n == 6 or n == 8):
-        raise Exception("{} is no a legal entry for n. Choose 4, 6 or 8.".format(n))
-
-    dictionary_name = "{}_{}_player_{}_dictionary".format(dictionary_type, n, draft_stage.name)
-
-    return dictionary_name
-
-
-def get_arbitrary_dictionary_entry(dictionary):
-    dictionary_keys = list(dictionary.keys())
-
-    if 'descriptor' in dictionary_keys:
-        dictionary_keys.remove('descriptor')
-
-    if (len(dictionary_keys) > 0):
-        arbitrary_dictionary_entry = dictionary[dictionary_keys[0]]
-        return arbitrary_dictionary_entry
-    else:
-        return None

--- a/drafter/data/initialise_dictionaries.py
+++ b/drafter/data/initialise_dictionaries.py
@@ -3,18 +3,17 @@ import csv
 
 import drafter.common.team_permutation as team_permutation  # local source
 from drafter.common.pairing import PairingTables
-import drafter.data.read_write as read_write
 import drafter.data.paths as paths
 import drafter.solver.context as context
-import drafter.solver.games as games
 import drafter.solver.strategy_dictionaries as strategy_dictionaries
 import drafter.solver.game_state_dictionaries as game_state_dictionaries
 
 
 def initialise(enemy_team_name, config):
-    """Load a match's input matrices, build the SolverContext, and solve the
-    whole draft tree into it. Returns the populated SolverContext (GitHub issue
-    #13, B2 solver-context refactor: no module-level globals)."""
+    """Load a match's input matrices, build the SolverContext, and solve the whole
+    draft tree into it (value-only, GitHub issue #13). Returns the populated
+    SolverContext. There is no disk cache: the solve is fast and low-RAM and lives
+    in-process for the whole draft session."""
     match_paths = paths.resolve_match(enemy_team_name)
 
     best = read_pairing_matrix(
@@ -41,50 +40,20 @@ def initialise(enemy_team_name, config):
         pairing=pairing,
         restriction=restriction,
         paths=match_paths,
-        gamestate_dictionaries=game_state_dictionaries.make_gamestate_dictionaries(),
-        strategy_dictionaries=strategy_dictionaries.make_strategy_dictionaries(),
-        game_solution_caches=games.make_game_solution_caches())
-
-    friendly_names = list(friendly.names)
-    enemy_names = list(enemy.names)
-
-    # Cached JSONs carry solved game values keyed by positional integer codes, so
-    # a cache written under an older value model or a different player set/order
-    # would load fine but be silently wrong. Only read caches whose marker matches
-    # the current engine and the current name ordering; the marker is written
-    # after a successful solve+write below.
-    caches_are_current = read_write.cache_format_is_current(
-        match_paths.cache_file(read_write.CACHE_FORMAT_FILENAME), friendly_names, enemy_names)
-    if (config.read_gamestates or config.read_strategies) and not caches_are_current:
-        print("Ignoring cached JSONs in this match folder (missing or outdated {}): "
-            "they were computed under an older value model. Solving fresh."
-            .format(read_write.CACHE_FORMAT_FILENAME))
+        gamestate_key_arrays={},
+        value_arrays={},
+        draft_strategy_cache={},
+        extension_values={})
 
     t0 = time.time()
-    print("Initialising gamestate dictionaries (This might take a few minutes):")
-    game_state_dictionaries.initialise_dictionaries(
-        ctx, config.read_gamestates and caches_are_current, config.write_gamestates)
+    print("Enumerating gamestates (This might take a few minutes):")
+    ctx.gamestate_key_arrays = game_state_dictionaries.enumerate_gamestates(ctx)
     print("time: {}s".format(round(time.time() - t0, 2)))
 
     t0 = time.time()
-    if config.read_strategies:
-        print("Initialising strategy dictionaries (This might take a few minutes):")
-    else:
-        if config.restrict_attackers and config.restricted_attackers_count < 4:
-            print("Initialising strategy dictionaries (This might take a few minutes):")
-        elif config.restrict_attackers and config.restricted_attackers_count < 5:
-            print("Initialising strategy dictionaries (This might take an hour.):")
-        else:
-            long_runtime_warning = ("Initialising strategy dictionaries (This might take many hours."
-                + " Enable restrict_attackers with restricted_attackers_count < 5 to reduce runtime.):")
-            print(long_runtime_warning)
-    strategy_dictionaries.initialise_dictionaries(
-        ctx, config.read_strategies and caches_are_current, config.write_strategies)
+    print("Solving game values (This might take a few minutes):")
+    strategy_dictionaries.initialise_values(ctx)
     print("time: {}s".format(round(time.time() - t0, 2)))
-
-    if config.write_gamestates and config.write_strategies:
-        read_write.write_cache_format_marker(
-            match_paths.cache_file(read_write.CACHE_FORMAT_FILENAME), friendly_names, enemy_names)
 
     return ctx
 

--- a/drafter/solver/context.py
+++ b/drafter/solver/context.py
@@ -43,11 +43,6 @@ class SolverConfig:
     # to the best-map value. 0.5 = midpoint, a 50/50 model of who ends up with
     # map advantage (PLAN.md workstream C).
     neutral_map_weight: float = 0.5
-    # JSON cache read/write toggles.
-    read_gamestates: bool = True
-    write_gamestates: bool = True
-    read_strategies: bool = True
-    write_strategies: bool = True
     # Maximum number of attacker players considered by each team in each select
     # attackers step. Default 4. Decrease to 3 for shorter runtime, increase to
     # 5 for better precision.
@@ -57,11 +52,18 @@ class SolverConfig:
 
 # Everything one solve run needs, passed around explicitly instead of read from
 # module-level globals (GitHub issue #13). Replaces drafter.data.match_info, the
-# mutable drafter.data.settings, the restrict-attackers caches that used to live
-# in drafter.common.team_permutation, and the gamestate/strategy dictionaries
-# that used to be module globals in the solver package. Gamestate keys are packed
-# integers (drafter.common.packing); the friendly/enemy NameIndex maps here are
-# the only place player names live.
+# mutable drafter.data.settings, and the restrict-attackers caches that used to
+# live in drafter.common.team_permutation. Gamestate keys are packed integers
+# (drafter.common.packing); the friendly/enemy NameIndex maps here are the only
+# place player names live.
+#
+# Value-only storage (B3): the whole solve lives in numpy arrays instead of
+# dictionaries of GameState / strategy objects --
+#   gamestate_key_arrays[(n, stage)] -> sorted int64 keys (enumeration output),
+#   value_arrays[(n, stage)]         -> StageValues(keys, values) (solved values),
+# with draft_strategy_cache (the handful of labelled strategies the draft
+# recomputes) and extension_values (values solved on demand for off-tree,
+# non-k-restricted moves).
 @dataclass
 class SolverContext:
     config: SolverConfig
@@ -71,6 +73,7 @@ class SolverContext:
     pairing: Any                      # drafter.common.pairing.PairingTables
     restriction: Any                  # team_permutation.RestrictionData | None
     paths: Any                        # drafter.data.paths.MatchPaths
-    gamestate_dictionaries: dict
-    strategy_dictionaries: dict
-    game_solution_caches: dict
+    gamestate_key_arrays: dict
+    value_arrays: dict
+    draft_strategy_cache: dict
+    extension_values: dict

--- a/drafter/solver/draft.py
+++ b/drafter/solver/draft.py
@@ -102,20 +102,14 @@ def play_draft(ctx):
             draft_finished = True
             break
 
-        update_dictionaries(ctx, current_gamestate)
-
     if draft_finished:
-        initial_n = gamestate_tree[0].get_n()
         print("\nDraft vs. {} finished!\n".format(ctx.enemy_team_name))
         print("Pairings:")
         for new_pairings in pairings:
             print(" - [{}]: {}".format(new_pairings[0], new_pairings[1]))
         result_sum = sum([pairing[0] for pairing in pairings])
         print("\nTotal: {}".format(round(result_sum, 2)))
-        initial_strategy_dictionary_name = utilities.get_strategy_dictionary_name(initial_n, DraftStage.select_defender)
-        initial_strategy_dictionary = ctx.strategy_dictionaries[initial_strategy_dictionary_name]
-        initial_strategy = utilities.get_arbitrary_dictionary_entry(initial_strategy_dictionary)
-        expected_result = initial_strategy[2]
+        expected_result = strategy_dictionaries.game_value(ctx, gamestate_tree[0])
         print("Expected result: {}".format(round(expected_result, 2)))
         difference = result_sum - expected_result
         print("Difference: {}".format(round(difference, 2)))
@@ -142,43 +136,10 @@ def play_draft(ctx):
 
 
 def get_team_strategies(ctx, _gamestate):
-    strategy_dictionary_name = _gamestate.get_strategy_dictionary_name()
-    strategy_dictionary = ctx.strategy_dictionaries[strategy_dictionary_name]
-    key = _gamestate.get_key()
-    team_strategies = strategy_dictionary[key]
-    return team_strategies
-
-
-def update_dictionaries(ctx, seed_gamestate):
-    seed_gamestate_dictionary_name = seed_gamestate.get_gamestate_dictionary_name()
-    gamestate_dictionary = ctx.gamestate_dictionaries[seed_gamestate_dictionary_name]
-    seed_gamestate_key = seed_gamestate.get_key()
-
-    if seed_gamestate_key not in gamestate_dictionary:
-        print("\nUnexpected selection made. Extending game dictionaries...")
-
-        added_gamestate_dictionaries = game_state_dictionaries.perform_gamestate_tree_extension(
-            ctx, {seed_gamestate_key: seed_gamestate}, [])
-
-        gamestate_dictionaries_to_process = []
-        for i in range(0, len(added_gamestate_dictionaries)):
-            gamestate_dictionary = added_gamestate_dictionaries[i]
-            gamestate_dictionary_draft_stage = utilities.get_arbitrary_dictionary_entry(
-                gamestate_dictionary).draft_stage
-
-            if gamestate_dictionary_draft_stage != DraftStage.discard_attacker:
-                gamestate_dictionaries_to_process.append(gamestate_dictionary)
-
-        gamestate_dictionaries_to_process = list(reversed(gamestate_dictionaries_to_process))
-
-        if len(gamestate_dictionaries_to_process) > 0:
-            first_gamestate_dictionary = gamestate_dictionaries_to_process[0]
-            first_arbitrary_gamestate = utilities.get_arbitrary_dictionary_entry(first_gamestate_dictionary)
-            lower_level_strategies = strategy_dictionaries.get_dictionary_for_gamestate(ctx, first_arbitrary_gamestate)
-
-            for gamestate_dictionary in gamestate_dictionaries_to_process:
-                lower_level_strategies = strategy_dictionaries.process_gamestate_dictionary(
-                    ctx, False, False, gamestate_dictionary, lower_level_strategies)
+    # Recompute the labelled strategy for the visited gamestate on demand from its
+    # children's values (GitHub issue #13, B3). The same recursion transparently
+    # solves any off-tree, non-k-restricted subtree the user navigates into.
+    return strategy_dictionaries.game_strategy(ctx, _gamestate)
 
 
 def prompt_next_gamestate(ctx, _gamestate, gamestate_team_strategies, next_draft_stage):

--- a/drafter/solver/game_state_dictionaries.py
+++ b/drafter/solver/game_state_dictionaries.py
@@ -1,177 +1,55 @@
-import drafter.common.utilities as utilities  # local source
-import drafter.common.game_state as game_state
+import numpy as np  # 3rd party packages
+
+import drafter.common.game_state as game_state  # local source
 from drafter.common.game_state import GameState
 from drafter.common.team_permutation import TeamPermutation
 from drafter.common.draft_stage import DraftStage
 import drafter.common.draft_stage as draft_stage
-import drafter.data.read_write as read_write
-
-global_gamestate_dictionary_names = [
-    utilities.get_gamestate_dictionary_name(8, DraftStage.none),
-    utilities.get_gamestate_dictionary_name(8, DraftStage.select_defender),
-    utilities.get_gamestate_dictionary_name(8, DraftStage.select_attackers),
-    utilities.get_gamestate_dictionary_name(8, DraftStage.discard_attacker),
-    utilities.get_gamestate_dictionary_name(6, DraftStage.none),
-    utilities.get_gamestate_dictionary_name(6, DraftStage.select_defender),
-    utilities.get_gamestate_dictionary_name(6, DraftStage.select_attackers),
-    utilities.get_gamestate_dictionary_name(6, DraftStage.discard_attacker),
-    utilities.get_gamestate_dictionary_name(4, DraftStage.none),
-    utilities.get_gamestate_dictionary_name(4, DraftStage.select_defender),
-    utilities.get_gamestate_dictionary_name(4, DraftStage.select_attackers)]
-
-
-def make_gamestate_dictionaries():
-    # A fresh, empty gamestate store for one SolverContext (GitHub issue #13);
-    # replaces the module-level `dictionaries` global.
-    return {name: {} for name in global_gamestate_dictionary_names}
-
-
-def initialise_dictionaries(ctx, read, write):
-    dictionaries_loaded_from_files = False
-    if read:
-        dictionaries_loaded_from_files = read_dictionaries(ctx)
-
-    if not dictionaries_loaded_from_files:
-        initial_game_state = get_initial_game_state(ctx)
-        seed_dictionary = {'seed': initial_game_state}
-        perform_gamestate_tree_extension(ctx, seed_dictionary)
-
-        if write:
-            write_dictionaries(ctx)
-
-
-def read_dictionaries(ctx):
-    for name in global_gamestate_dictionary_names:
-        path = ctx.paths.cache_file(name + ".json")
-        key_list = read_write.read_dictionary(path)
-
-        if (key_list is not None and len(key_list) > 0):
-            # JSON turns the (friendly, enemy) tuple keys into 2-element lists;
-            # tuple them back so they are hashable dict keys again.
-            ctx.gamestate_dictionaries[name] = {
-                tuple(key): game_state.get_gamestate_from_key(key) for key in key_list}
-        else:
-            return False
-
-    return True
-
-
-def write_dictionaries(ctx):
-    for name in global_gamestate_dictionary_names:
-        path = ctx.paths.cache_file(name + ".json")
-        # The (friendly, enemy) integer-code tuples serialise to JSON as lists.
-        key_list = [key for key in ctx.gamestate_dictionaries[name]]
-        read_write.write_dictionary(path, key_list)
+import drafter.common.packing as packing
 
 
 def get_initial_game_state(ctx):
     friends = list(range(len(ctx.friendly.names)))
     enemies = list(range(len(ctx.enemy.names)))
-    initial_game_state = GameState(DraftStage.none, TeamPermutation(friends), TeamPermutation(enemies))
-
-    return initial_game_state
+    return GameState(DraftStage.none, TeamPermutation(friends), TeamPermutation(enemies))
 
 
-def perform_gamestate_tree_extension(ctx, parent_dictionary, new_gamestates_dictionaries=None):
-    current_arbitrary_gamestate = utilities.get_arbitrary_dictionary_entry(parent_dictionary)
-    current_global_gamestate_dictionary_name = current_arbitrary_gamestate.get_gamestate_dictionary_name()
-    print_extend_dictionaries(current_global_gamestate_dictionary_name, new_gamestates_dictionaries)
-
-    produced_gamestate_dictionaries = extend_gamestate_tree_from_seed_dictionary(ctx, parent_dictionary, new_gamestates_dictionaries)
-
-    if produced_gamestate_dictionaries is not None:
-        produced_gamestate_dictionaries = [new_gamestates_dictionary for new_gamestates_dictionary
-            in produced_gamestate_dictionaries if len(new_gamestates_dictionary) > 0]
-
-    return produced_gamestate_dictionaries
+def stage_of_key(gamestate_key):
+    # (n, draft_stage) of a gamestate, derived from its packed friendly team code.
+    friendly_code = packing.decode_gamestate(int(gamestate_key))[0]
+    return (packing.team_permutation_n(friendly_code), packing.draft_stage_of_code(friendly_code))
 
 
-def extend_gamestate_tree_from_seed_dictionary(ctx, parent_dictionary, new_gamestate_dictionaries=None):
-    if len(parent_dictionary) == 0:
-        return new_gamestate_dictionaries
+def enumerate_gamestates(ctx):
+    """Breadth-first from the initial gamestate, returning
+    {(n, draft_stage): sorted numpy int64 array of gamestate keys} for the
+    select_defender/select_attackers/none stages that the backward induction
+    solves (GitHub issue #13, B3). Only integer keys are kept -- GameState objects
+    are decoded on demand -- so the whole tree costs ~12 MB instead of ~1 GB.
+    """
+    key_arrays = {}
+    # Each BFS level is a single (n, stage); np.unique gives a sorted, deduped
+    # int64 array (deduping via numpy rather than a Python set keeps the transient
+    # peak low, which is the point of B3).
+    current_level = np.array([get_initial_game_state(ctx).get_key()], dtype=np.int64)
 
-    current_arbitrary_gamestate = utilities.get_arbitrary_dictionary_entry(parent_dictionary)
+    while len(current_level) > 0:
+        n, stage = stage_of_key(int(current_level[0]))
 
-    current_draft_stage = current_arbitrary_gamestate.draft_stage
-    current_n = current_arbitrary_gamestate.get_n()
+        # The discard levels are pass-through only (their value is computed at the
+        # parent select_attackers gamestate); we don't solve them, so don't store.
+        if stage != DraftStage.discard_attacker:
+            key_arrays[(n, stage)] = current_level
 
-    current_global_gamestate_dictionary_name = utilities.get_gamestate_dictionary_name(current_n, current_draft_stage)
-    current_global_dictionary = ctx.gamestate_dictionaries[current_global_gamestate_dictionary_name]
+        # The 4-player discard is the closed-form endgame; stop before generating it.
+        if n == 4 and draft_stage.get_next_draft_stage(stage) == DraftStage.discard_attacker:
+            break
 
-    if (current_global_dictionary is None):
-        return new_gamestate_dictionaries
+        child_keys = []
+        for gamestate_key in current_level:
+            gamestate = game_state.get_gamestate_from_key(int(gamestate_key))
+            for child in game_state.get_next_gamestates(ctx, gamestate):
+                child_keys.append(child.get_key())
+        current_level = np.unique(np.array(child_keys, dtype=np.int64))
 
-    parent_gamestates = [parent_dictionary[key] for key in parent_dictionary]
-    added_subdictionary = add_gamestates_to_dictionary(current_global_dictionary, parent_gamestates)
-
-    print("    - Done: {} gamestates added".format(len(added_subdictionary)))
-
-    if len(added_subdictionary) == 0:
-        return new_gamestate_dictionaries
-
-    if (new_gamestate_dictionaries is not None):
-        new_gamestate_dictionaries.append(added_subdictionary)
-
-    next_draft_stage = draft_stage.get_next_draft_stage(current_draft_stage)
-    next_n = current_n
-
-    if (next_n == 4 and next_draft_stage == DraftStage.discard_attacker):
-        return new_gamestate_dictionaries
-
-    next_global_gamestate_dictionary_name = utilities.get_gamestate_dictionary_name(next_n, next_draft_stage)
-
-    print_extend_dictionaries(next_global_gamestate_dictionary_name, new_gamestate_dictionaries)
-
-    generated_gamestate_dictionary = {}
-    for parent_key in parent_dictionary:
-        parent_gamestate = parent_dictionary[parent_key]
-        child_gamestates = game_state.get_next_gamestates(ctx, parent_gamestate)
-        add_gamestates_to_dictionary(generated_gamestate_dictionary, child_gamestates)
-
-    extend_gamestate_tree_from_seed_dictionary(ctx, generated_gamestate_dictionary, new_gamestate_dictionaries)
-
-    return new_gamestate_dictionaries
-
-
-def print_extend_dictionaries(dictionary_name, new_gamestate_dictionaries):
-    if new_gamestate_dictionaries is None:
-        description = "Initialising"
-    else:
-        description = "Extending"
-
-    print(" - {} {}...".format(description, dictionary_name))
-
-
-def add_gamestates_to_dictionary(dictionary, gamestates):
-    added_subdictionary = {}
-
-    for gamestate_var in gamestates:
-        key = gamestate_var.get_key()
-
-        if key not in dictionary:
-            dictionary[key] = gamestate_var
-            added_subdictionary[key] = gamestate_var
-
-    return added_subdictionary
-
-
-def get_previous_gamestate_dictionary(ctx, gamestate_dictionary):
-    arbitrary_gamestate = utilities.get_arbitrary_dictionary_entry(gamestate_dictionary)
-    n = arbitrary_gamestate.get_n()
-    current_draft_stage = arbitrary_gamestate.draft_stage
-
-    if n == 8 and current_draft_stage == DraftStage.none:
-        return None
-
-    previous_draft_stage = draft_stage.get_previous_draft_stage(current_draft_stage)
-
-    if (previous_draft_stage == DraftStage.discard_attacker):
-        n += 2
-
-        if n > 10:
-            return None
-
-    next_gamestate_dictionary_name = utilities.get_gamestate_dictionary_name(n, previous_draft_stage)
-    next_gamestate_dictionary = ctx.gamestate_dictionaries[next_gamestate_dictionary_name]
-
-    return next_gamestate_dictionary
+    return key_arrays

--- a/drafter/solver/games.py
+++ b/drafter/solver/games.py
@@ -1,140 +1,93 @@
-import numpy as np  # standard libraries
+import numpy as np  # 3rd party packages
 
-import drafter.common.utilities as utilities  # local source
-import drafter.common.game_state as game_state
+import drafter.common.game_state as game_state  # local source
 from drafter.common.game_state import GameState
 from drafter.common.team_permutation import TeamPermutation
 from drafter.common.draft_stage import DraftStage
 from drafter.common.pairing import Defender
 
-STAGES = ("select_defender", "select_attackers", "discard_attacker")
+
+# Build the payoff matrix (and its row/column option labels) for the game decided
+# at `gamestate`, reading each child gamestate's value through get_child_value
+# (GitHub issue #13, B3). Backward induction feeds it a direct array lookup; the
+# draft loop feeds it a recursive on-demand value. Returns
+# (game_array, friendly_options, enemy_options); the caller solves for the value
+# (utilities.get_game_value) or the labelled strategy (utilities.get_game_strategy).
+def build_game(ctx, gamestate, get_child_value):
+    stage = gamestate.draft_stage
+    if stage == DraftStage.none:
+        return build_select_defender_game(ctx, gamestate, get_child_value)
+    elif stage == DraftStage.select_defender:
+        return build_select_attackers_game(ctx, gamestate, get_child_value)
+    elif stage == DraftStage.select_attackers:
+        return build_discard_game(ctx, gamestate, get_child_value)
+    else:
+        raise ValueError("Cannot build a game for draft stage {}.".format(stage))
 
 
-def make_game_solution_caches():
-    # One matrix-hash cache per (draft stage, n). Content-keyed memoisation of
-    # solved zero-sum games; lives on the SolverContext instead of module-level
-    # globals (GitHub issue #13).
-    return {stage: {4: {}, 6: {}, 8: {}} for stage in STAGES}
-
-
-def select_defender(ctx, n, none_gamestate, select_attackers_strategies):
+def build_select_defender_game(ctx, none_gamestate, get_child_value):
     gamestate_matrix = game_state.get_next_gamestate_matrix(ctx, none_gamestate)
-    friendly_team_options = [row[0].friendly_team_permutation.defender for row in gamestate_matrix]
-    enemy_team_options = [_gamestate.enemy_team_permutation.defender for _gamestate in gamestate_matrix[0]]
-    game_array = get_game_array(gamestate_matrix, select_attackers_strategies)
-    select_defender_strategy = utilities.get_game_strategy(ctx.game_solution_caches["select_defender"][n],
-        game_array, friendly_team_options, enemy_team_options)
-
-    return select_defender_strategy
+    friendly_options = [row[0].friendly_team_permutation.defender for row in gamestate_matrix]
+    enemy_options = [gamestate.enemy_team_permutation.defender for gamestate in gamestate_matrix[0]]
+    game_array = np.array([[get_child_value(gamestate.get_key()) for gamestate in row]
+                           for row in gamestate_matrix])
+    return game_array, friendly_options, enemy_options
 
 
-def select_attackers(ctx, n, selected_defender_gamestate, discard_attacker_strategies):
+def build_select_attackers_game(ctx, selected_defender_gamestate, get_child_value):
     gamestate_matrix = game_state.get_next_gamestate_matrix(ctx, selected_defender_gamestate)
-
-    friendly_team_options = [[row[0].friendly_team_permutation.attacker_A,
+    friendly_options = [[row[0].friendly_team_permutation.attacker_A,
         row[0].friendly_team_permutation.attacker_B] for row in gamestate_matrix]
-
-    enemy_team_options = [[gamestate.enemy_team_permutation.attacker_A,
-        gamestate.enemy_team_permutation.attacker_B] for gamestate in gamestate_matrix[0]]  # TODO ?
-
-    game_array = get_game_array(gamestate_matrix, discard_attacker_strategies)
-
-    select_attackers_strategy = utilities.get_game_strategy(ctx.game_solution_caches["select_attackers"][n],
-        game_array, friendly_team_options, enemy_team_options)
-
-    return select_attackers_strategy
+    enemy_options = [[gamestate.enemy_team_permutation.attacker_A,
+        gamestate.enemy_team_permutation.attacker_B] for gamestate in gamestate_matrix[0]]
+    game_array = np.array([[get_child_value(gamestate.get_key()) for gamestate in row]
+                           for row in gamestate_matrix])
+    return game_array, friendly_options, enemy_options
 
 
-def get_game_array(gamestate_matrix, lower_level_strategies):
-    game_matrix = []
-
-    for gamestate_row in gamestate_matrix:
-
-        matrix_row = []
-
-        for _gamestate in gamestate_row:
-            game_overview = lower_level_strategies[_gamestate.get_key()]
-            game_value = game_overview[2]
-            matrix_row.append(game_value)
-
-        game_matrix.append(matrix_row)
-
-    game_array = np.array(game_matrix)
-
-    return game_array
-
-
-def discard_attacker(ctx, n, selected_attackers_gamestate, select_defender_strategies):
-    def get_game_key(extra_friend, extra_enemy):
-        friendly_team_permutation = TeamPermutation(
-            selected_attackers_gamestate.friendly_team_permutation.remaining_players + [extra_friend])
-
-        enemy_team_permutation = TeamPermutation(
-            selected_attackers_gamestate.enemy_team_permutation.remaining_players + [extra_enemy])
-
-        game_permutation = GameState(DraftStage.none, friendly_team_permutation, enemy_team_permutation)
-        game_key = game_permutation.get_key()
-
-        return game_key
-
-    f_defender = selected_attackers_gamestate.friendly_team_permutation.defender
-    f_attacker_A = selected_attackers_gamestate.friendly_team_permutation.attacker_A
-    f_attacker_B = selected_attackers_gamestate.friendly_team_permutation.attacker_B
-    remaining_friends = selected_attackers_gamestate.friendly_team_permutation.remaining_players
-
-    e_defender = selected_attackers_gamestate.enemy_team_permutation.defender
-    e_attacker_A = selected_attackers_gamestate.enemy_team_permutation.attacker_A
-    e_attacker_B = selected_attackers_gamestate.enemy_team_permutation.attacker_B
-    remaining_enemies = selected_attackers_gamestate.enemy_team_permutation.remaining_players
-
-    if n == 4:
-        return discard_attacker_4(ctx, f_defender, f_attacker_A, f_attacker_B, remaining_friends[0],
-            e_defender, e_attacker_A, e_attacker_B, remaining_enemies[0])
+def build_discard_game(ctx, selected_attackers_gamestate, get_child_value):
+    friendly = selected_attackers_gamestate.friendly_team_permutation
+    enemy = selected_attackers_gamestate.enemy_team_permutation
+    f_defender, f_attacker_A, f_attacker_B = friendly.defender, friendly.attacker_A, friendly.attacker_B
+    e_defender, e_attacker_A, e_attacker_B = enemy.defender, enemy.attacker_A, enemy.attacker_B
 
     fD_eA = ctx.pairing.value(f_defender, e_attacker_A, Defender.FRIENDLY)
     fD_eB = ctx.pairing.value(f_defender, e_attacker_B, Defender.FRIENDLY)
     fA_eD = ctx.pairing.value(f_attacker_A, e_defender, Defender.ENEMY)
     fB_eD = ctx.pairing.value(f_attacker_B, e_defender, Defender.ENEMY)
 
-    # The child gamestate receives the REFUSED attackers back into the pools
-    # (issue #32): in AB, e_B plays the friendly defender and f_A plays the
-    # enemy defender, so the refused pair returning to the pools is (f_B, e_A)
-    # -- and mirrored in BA. The kept attackers' games are the fD_*/f*_eD terms.
-    AA = fD_eB + fB_eD + select_defender_strategies[get_game_key(f_attacker_A, e_attacker_A)][2]
-    AB = fD_eB + fA_eD + select_defender_strategies[get_game_key(f_attacker_B, e_attacker_A)][2]
-    BA = fD_eA + fB_eD + select_defender_strategies[get_game_key(f_attacker_A, e_attacker_B)][2]
-    BB = fD_eA + fA_eD + select_defender_strategies[get_game_key(f_attacker_B, e_attacker_B)][2]
+    if selected_attackers_gamestate.get_n() == 4:
+        # 4-player endgame: refused-vs-refused and last-vs-last play each other,
+        # so the two remaining players give a fixed extra term (no child game).
+        f_not_selected = friendly.remaining_players[0]
+        e_not_selected = enemy.remaining_players[0]
+
+        fA_eA = ctx.pairing.value(f_attacker_A, e_attacker_A)
+        fA_eB = ctx.pairing.value(f_attacker_A, e_attacker_B)
+        fB_eA = ctx.pairing.value(f_attacker_B, e_attacker_A)
+        fB_eB = ctx.pairing.value(f_attacker_B, e_attacker_B)
+        fN_eN = ctx.pairing.value(f_not_selected, e_not_selected)
+
+        AA = fD_eB + fB_eD + fA_eA + fN_eN
+        AB = fD_eB + fA_eD + fB_eA + fN_eN
+        BA = fD_eA + fB_eD + fA_eB + fN_eN
+        BB = fD_eA + fA_eD + fB_eB + fN_eN
+    else:
+        # The child 'none' gamestate receives the REFUSED attackers back into the
+        # pools (issue #32): in AB, e_B plays the friendly defender and f_A plays
+        # the enemy defender, so the refused pair returning to the pools is
+        # (f_B, e_A) -- mirrored in BA. The kept attackers' games are the
+        # fD_*/f*_eD terms.
+        def child_value(extra_friend, extra_enemy):
+            child = GameState(DraftStage.none,
+                TeamPermutation(friendly.remaining_players + [extra_friend]),
+                TeamPermutation(enemy.remaining_players + [extra_enemy]))
+            return get_child_value(child.get_key())
+
+        AA = fD_eB + fB_eD + child_value(f_attacker_A, e_attacker_A)
+        AB = fD_eB + fA_eD + child_value(f_attacker_B, e_attacker_A)
+        BA = fD_eA + fB_eD + child_value(f_attacker_A, e_attacker_B)
+        BB = fD_eA + fA_eD + child_value(f_attacker_B, e_attacker_B)
 
     game_array = np.array([[AA, AB], [BA, BB]])
-    discard_attacker_strategy = utilities.get_game_strategy(ctx.game_solution_caches["discard_attacker"][n], game_array,
-        [e_attacker_A, e_attacker_B], [f_attacker_A, f_attacker_B])
-
-    return discard_attacker_strategy
-
-
-def discard_attacker_4(ctx, f_defender, f_attacker_A, f_attacker_B, f_not_selected, e_defender,
-        e_attacker_A, e_attacker_B, e_not_selected):
-
-    fD_eA = ctx.pairing.value(f_defender, e_attacker_A, Defender.FRIENDLY)
-    fD_eB = ctx.pairing.value(f_defender, e_attacker_B, Defender.FRIENDLY)
-    fA_eD = ctx.pairing.value(f_attacker_A, e_defender, Defender.ENEMY)
-    fB_eD = ctx.pairing.value(f_attacker_B, e_defender, Defender.ENEMY)
-
-    fA_eA = ctx.pairing.value(f_attacker_A, e_attacker_A)
-    fA_eB = ctx.pairing.value(f_attacker_A, e_attacker_B)
-    fB_eA = ctx.pairing.value(f_attacker_B, e_attacker_A)
-    fB_eB = ctx.pairing.value(f_attacker_B, e_attacker_B)
-
-    fN_eN = ctx.pairing.value(f_not_selected, e_not_selected)
-
-    AA = fD_eB + fB_eD + fA_eA + fN_eN
-    AB = fD_eB + fA_eD + fB_eA + fN_eN
-    BA = fD_eA + fB_eD + fA_eB + fN_eN
-    BB = fD_eA + fA_eD + fB_eB + fN_eN
-
-    game_array = np.array([[AA, AB], [BA, BB]])
-
-    discard_attacker_strategy = utilities.get_game_strategy(ctx.game_solution_caches["discard_attacker"][4],
-        game_array, [e_attacker_A, e_attacker_B], [f_attacker_A, f_attacker_B])
-
-    return discard_attacker_strategy
+    return game_array, [e_attacker_A, e_attacker_B], [f_attacker_A, f_attacker_B]

--- a/drafter/solver/strategy_dictionaries.py
+++ b/drafter/solver/strategy_dictionaries.py
@@ -1,165 +1,121 @@
-import math  # standard libraries
-import sys
-import time
+"""Value-only backward induction (GitHub issue #13, B3).
+
+The tree only propagates game *values*, stored per (n, draft_stage) as parallel
+sorted numpy arrays (keys + values) with binary-search lookup -- ~8 MB total
+instead of the ~810 MB of full strategy vectors the old strategy dictionaries
+held. The interactive draft recomputes the labelled mixed strategy on demand for
+the ~20 gamestates it actually visits (games.build_game + get_game_strategy), and
+the same recursion transparently solves any off-tree (non-k-restricted) subtree
+the user navigates into -- no separate tree-extension machinery.
+"""
+import numpy as np  # 3rd party packages
 
 import drafter.common.utilities as utilities  # local source
-import drafter.common.draft_stage as draft_stage
+import drafter.common.game_state as game_state
+import drafter.common.packing as packing
 from drafter.common.draft_stage import DraftStage
-import drafter.data.read_write as read_write
 import drafter.solver.games as games
-import drafter.solver.game_state_dictionaries as game_state_dictionaries
-
-def make_strategy_dictionaries():
-    # A fresh strategy store for one SolverContext (GitHub issue #13); replaces
-    # the module-level `dictionaries` global. Each per-(n, stage) sub-dictionary
-    # is seeded with its 'descriptor' so get_dictionary_for_gamestate can match
-    # it before any strategies are solved.
-    dictionaries = {}
-    for n in (8, 6, 4):
-        for stage in (DraftStage.select_defender, DraftStage.select_attackers, DraftStage.discard_attacker):
-            dictionaries[utilities.get_strategy_dictionary_name(n, stage)] = {'descriptor': [n, stage]}
-    return dictionaries
 
 
-def initialise_dictionaries(ctx, read, write):
-    final_gamestate_dictionary_name = utilities.get_gamestate_dictionary_name(4, DraftStage.select_attackers)
-    gamestate_dictionary = ctx.gamestate_dictionaries[final_gamestate_dictionary_name]
+class StageValues:
+    """Solved game values for one (n, draft_stage), as a sorted key array and a
+    parallel value array; O(log n) binary-search lookup."""
+    __slots__ = ("keys", "values")
 
-    strategy_dictionary = process_gamestate_dictionary(ctx, read, write, gamestate_dictionary)
+    def __init__(self, keys, values):
+        self.keys = keys
+        self.values = values
 
-    while strategy_dictionary is not None:
-        gamestate_dictionary = game_state_dictionaries.get_previous_gamestate_dictionary(ctx, gamestate_dictionary)
+    def contains(self, gamestate_key):
+        index = np.searchsorted(self.keys, gamestate_key)
+        return index < len(self.keys) and self.keys[index] == gamestate_key
 
-        if (gamestate_dictionary is None):
-            break
-
-        arbitrary_gamestate = utilities.get_arbitrary_dictionary_entry(gamestate_dictionary)
-        if (arbitrary_gamestate is None):
-            break
-        elif (arbitrary_gamestate.draft_stage == DraftStage.discard_attacker):
-            gamestate_dictionary = game_state_dictionaries.get_previous_gamestate_dictionary(ctx, gamestate_dictionary)
-
-        if (gamestate_dictionary is None):
-            break
-
-        strategy_dictionary = process_gamestate_dictionary(ctx, read, write, gamestate_dictionary, strategy_dictionary)
+    def value(self, gamestate_key):
+        return float(self.values[np.searchsorted(self.keys, gamestate_key)])
 
 
-def update_dictionaries(ctx, read, write, gamestate_dictionaries):
-    reversed_gamestate_dictionaries = reversed(gamestate_dictionaries)
-    lower_level_strategies = None
+# Deepest first: a gamestate's game reads the values of its children, so children
+# must be solved before their parents.
+def solve_order():
+    order = []
+    for n in (4, 6, 8):
+        for stage in (DraftStage.select_attackers, DraftStage.select_defender, DraftStage.none):
+            order.append((n, stage))
+    return order
 
-    for gamestate_dictionary in reversed_gamestate_dictionaries:
-        arbitrary_gamestate = utilities.get_arbitrary_dictionary_entry(gamestate_dictionary)
-        if arbitrary_gamestate.draft_stage == DraftStage.discard_attacker:
+
+def child_stage(n, stage):
+    # The stage whose gamestate values the (n, stage) game is built from.
+    if stage == DraftStage.none:
+        return (n, DraftStage.select_defender)
+    if stage == DraftStage.select_defender:
+        return (n, DraftStage.select_attackers)
+    if stage == DraftStage.select_attackers:
+        return (n - 2, DraftStage.none)  # the discard game's 'none' subgames (n>4)
+    raise ValueError("No child stage for {}.".format(stage))
+
+
+def initialise_values(ctx):
+    """Solve every enumerated gamestate's value into ctx.value_arrays, deepest
+    stage first."""
+    for (n, stage) in solve_order():
+        keys = ctx.gamestate_key_arrays.get((n, stage))
+        if keys is None or len(keys) == 0:
             continue
 
-        lower_level_strategies = process_gamestate_dictionary(ctx, read, write, gamestate_dictionary, lower_level_strategies)
+        child_store = ctx.value_arrays.get(child_stage(n, stage))
+        get_child_value = child_store.value if child_store is not None else _missing_child
+
+        values = np.empty(len(keys), dtype=float)
+        for index in range(len(keys)):
+            gamestate = game_state.get_gamestate_from_key(int(keys[index]))
+            game_array, _, _ = games.build_game(ctx, gamestate, get_child_value)
+            values[index] = utilities.get_game_value(game_array)
+
+        ctx.value_arrays[(n, stage)] = StageValues(keys, values)
 
 
-def process_gamestate_dictionary(ctx, read, write, gamestate_dictionary_to_solve, lower_level_strategies=None):
-    arbitrary_gamestate = utilities.get_arbitrary_dictionary_entry(gamestate_dictionary_to_solve)
-    strategy_dictionary_name = arbitrary_gamestate.get_strategy_dictionary_name()
-    path = ctx.paths.cache_file(strategy_dictionary_name + ".json")
-
-    draft_stage_strategies = None
-
-    if read:
-        # The strategy dict is keyed by (friendly, enemy) integer-code tuples,
-        # which JSON can't use as object keys, so it is persisted as a list of
-        # [key, strategy] pairs (GitHub issue #13, B2). Tuple the keys on read.
-        serialised = read_write.read_dictionary(path)
-        if serialised is not None:
-            draft_stage_strategies = {tuple(key): strategy for key, strategy in serialised}
-
-    if draft_stage_strategies is None:
-        draft_stage_strategies = get_strategy_dictionary(ctx, gamestate_dictionary_to_solve, lower_level_strategies)
-
-        if write:
-            read_write.write_dictionary(
-                path, [[list(key), strategy] for key, strategy in draft_stage_strategies.items()])
-
-    ctx.strategy_dictionaries[strategy_dictionary_name].update(draft_stage_strategies)
-
-    return ctx.strategy_dictionaries[strategy_dictionary_name]
+def _missing_child(gamestate_key):
+    raise KeyError("No child value store (should only happen for the 4-player endgame).")
 
 
-def get_strategy_dictionary(ctx, gamestate_dictionary_to_solve, lower_level_strategies):
-    arbitrary_gamestate = utilities.get_arbitrary_dictionary_entry(gamestate_dictionary_to_solve)
-    n = arbitrary_gamestate.get_n()
-    draft_stage_to_solve = draft_stage.get_next_draft_stage(arbitrary_gamestate.draft_stage)
+# --- draft-time lookups: recompute strategies / values on demand ---
 
-    if (not (n == 4 or n == 6 or n == 8)):
-        sys.exit("{} is not a valid number of players. Choose 4, 6 or 8.".format(n))
+def known_value(ctx, gamestate_key):
+    friendly_code = packing.decode_gamestate(gamestate_key)[0]
+    n = packing.team_permutation_n(friendly_code)
+    stage = packing.draft_stage_of_code(friendly_code)
 
-    print(" - Generating {}-player {} strategies:".format(n, draft_stage_to_solve.name))
-    counter = 0
-    percentage = -1
-    draft_stage_strategies = {}
-    previous_time = time.time()
-    for key in gamestate_dictionary_to_solve:
-        gamestate_to_solve = gamestate_dictionary_to_solve[key]
-        counter += 1
-        new_percentage = math.floor(10 * counter / len(gamestate_dictionary_to_solve))
-        new_time = time.time()
-        if (new_percentage > percentage):
-            percentage = new_percentage
-            print("    - {}%: ".format(10 * percentage), counter, "/", len(list(gamestate_dictionary_to_solve)))
-            previous_time = new_time
-        elif new_time - previous_time > 30:
-            print("    - {}%: ".format(round(100 * counter / len(gamestate_dictionary_to_solve), 1)),
-                counter, "/", len(list(gamestate_dictionary_to_solve)))
+    store = ctx.value_arrays.get((n, stage))
+    if store is not None and store.contains(gamestate_key):
+        return store.value(gamestate_key)
 
-            previous_time = new_time
-
-        if draft_stage_to_solve == DraftStage.select_defender:
-            strategy = games.select_defender(ctx, n, gamestate_to_solve, lower_level_strategies)
-        elif draft_stage_to_solve == DraftStage.select_attackers:
-            strategy = games.select_attackers(ctx, n, gamestate_to_solve, lower_level_strategies)
-        elif draft_stage_to_solve == DraftStage.discard_attacker:
-            strategy = games.discard_attacker(ctx, n, gamestate_to_solve, lower_level_strategies)
-        else:
-            raise ValueError("Unsolvavle draft stage: {}.".format(draft_stage_to_solve))
-
-        draft_stage_strategies[gamestate_to_solve.get_key()] = strategy
-
-    return draft_stage_strategies
+    return ctx.extension_values.get(gamestate_key)
 
 
-def extend_dictionary(ctx, new_gamestates_to_solve, lower_level_strategies):
-    arbitrary_gamestate = new_gamestates_to_solve[list(new_gamestates_to_solve.keys())[0]]
-    strategy_dictionary_name = arbitrary_gamestate.get_strategy_dictionary_name()
+def game_value(ctx, gamestate):
+    """The value of `gamestate`: precomputed if it's on the solved tree, else
+    solved on demand (recursively) and memoised -- this is what lets the draft
+    follow off-tree, non-k-restricted moves."""
+    gamestate_key = gamestate.get_key()
 
-    strategies = get_strategy_dictionary(ctx, new_gamestates_to_solve, lower_level_strategies)
-    dictionary_to_update = ctx.strategy_dictionaries[strategy_dictionary_name]
-    dictionary_to_update.update(strategies)
+    value = known_value(ctx, gamestate_key)
+    if value is not None:
+        return value
 
-    return strategies
+    game_array, _, _ = games.build_game(ctx, gamestate, _child_value_getter(ctx))
+    value = utilities.get_game_value(game_array)
+    ctx.extension_values[gamestate_key] = value
+    return value
 
 
-def get_dictionary_for_gamestate(ctx, achieved_gamestate):
-    n = achieved_gamestate.get_n()
-    achieved_draft_stage = achieved_gamestate.draft_stage
+def game_strategy(ctx, gamestate):
+    """The labelled mixed strategy for the game decided at `gamestate`, recomputed
+    from its children's values (one solve; the draft visits ~20 gamestates)."""
+    game_array, friendly_options, enemy_options = games.build_game(
+        ctx, gamestate, _child_value_getter(ctx))
+    return utilities.get_game_strategy(ctx.draft_strategy_cache, game_array, friendly_options, enemy_options)
 
-    draft_stage_to_solve = draft_stage.get_next_draft_stage(achieved_draft_stage)
-    if draft_stage_to_solve == DraftStage.none:
-        draft_stage_to_solve = draft_stage.get_next_draft_stage(draft_stage_to_solve)
 
-    supporting_draft_stage = draft_stage.get_next_draft_stage(draft_stage_to_solve)
-    if supporting_draft_stage == DraftStage.none:
-        supporting_draft_stage = draft_stage.get_next_draft_stage(supporting_draft_stage)
-
-    if supporting_draft_stage.value < achieved_draft_stage.value:
-        n -= 2
-
-    if n < 4:
-        return None
-
-    for key in ctx.strategy_dictionaries:
-        dictionary = ctx.strategy_dictionaries[key]
-        descriptor = dictionary['descriptor']
-
-        if n == descriptor[0] and supporting_draft_stage == descriptor[1]:
-            return dictionary
-
-    return None
+def _child_value_getter(ctx):
+    return lambda child_key: game_value(ctx, game_state.get_gamestate_from_key(child_key))

--- a/drafter/solver/strategy_dictionaries.py
+++ b/drafter/solver/strategy_dictionaries.py
@@ -26,12 +26,21 @@ class StageValues:
         self.keys = keys
         self.values = values
 
-    def contains(self, gamestate_key):
+    def get(self, gamestate_key):
+        # Value for the key, or None if this stage doesn't hold it (one search).
         index = np.searchsorted(self.keys, gamestate_key)
-        return index < len(self.keys) and self.keys[index] == gamestate_key
+        if index < len(self.keys) and self.keys[index] == gamestate_key:
+            return float(self.values[index])
+        return None
 
     def value(self, gamestate_key):
-        return float(self.values[np.searchsorted(self.keys, gamestate_key)])
+        # Hot-path lookup for keys known to be present (backward induction reads
+        # only already-solved children). Guarded so a future mis-wire fails loudly
+        # instead of silently returning a neighbouring value.
+        result = self.get(gamestate_key)
+        if result is None:
+            raise KeyError("Gamestate key {} not in this stage's solved values.".format(gamestate_key))
+        return result
 
 
 # Deepest first: a gamestate's game reads the values of its children, so children
@@ -76,7 +85,9 @@ def initialise_values(ctx):
 
 
 def _missing_child(gamestate_key):
-    raise KeyError("No child value store (should only happen for the 4-player endgame).")
+    # Only wired for the 4-player select_attackers stage, whose discard game is
+    # closed-form and never looks up a child value; reaching here is a bug.
+    raise KeyError("No child value store for the requested gamestate: {}.".format(gamestate_key))
 
 
 # --- draft-time lookups: recompute strategies / values on demand ---
@@ -87,8 +98,10 @@ def known_value(ctx, gamestate_key):
     stage = packing.draft_stage_of_code(friendly_code)
 
     store = ctx.value_arrays.get((n, stage))
-    if store is not None and store.contains(gamestate_key):
-        return store.value(gamestate_key)
+    if store is not None:
+        precomputed = store.get(gamestate_key)
+        if precomputed is not None:
+            return precomputed
 
     return ctx.extension_values.get(gamestate_key)
 

--- a/drafter/tests/_solve_fixture.py
+++ b/drafter/tests/_solve_fixture.py
@@ -1,14 +1,11 @@
 """Helper script (not a pytest module) run as a subprocess by the golden-value
-tests. Solves one fixture fresh (cache read/write disabled) and prints a
-single JSON line to stdout with the top-level game value and top-level
-friendly/enemy strategies.
+tests. Solves one fixture fresh and prints a single JSON line to stdout with the
+top-level game value and top-level friendly/enemy strategies.
 
-Isolation rationale: even after the B2 solver-context refactor (GitHub issue
-#13) removed drafter's settings/match_info/dictionaries module globals, a few
-correctness-neutral memoisation caches remain module-level (the LP normalised
-cache in drafter.common.utilities). Running each solve in a fresh subprocess
-(like scripts/smoke_draft.py does for the interactive draft) gives every test a
-brand-new interpreter and brand-new module state, so nothing can leak between
+Isolation rationale: a couple of correctness-neutral memoisation caches are
+module-level (the LP normalised cache in drafter.common.utilities). Running each
+solve in a fresh subprocess (like scripts/smoke_draft.py does for the interactive
+draft) gives every test a brand-new interpreter, so nothing leaks between
 fixtures.
 
 Usage:
@@ -28,40 +25,25 @@ import drafter.solver.context as context
 fixture_name = sys.argv[1]
 k = int(sys.argv[2])
 
-config = context.SolverConfig(
-    read_gamestates=False,
-    write_gamestates=False,
-    read_strategies=False,
-    write_strategies=False,
-    restrict_attackers=True,
-    restricted_attackers_count=k)
+config = context.SolverConfig(restrict_attackers=True, restricted_attackers_count=k)
 
 import drafter.data.initialise_dictionaries as initialise_dictionaries
-import drafter.common.utilities as utilities
-import drafter.common.draft_stage as draft_stage_module
+import drafter.solver.game_state_dictionaries as game_state_dictionaries
+import drafter.solver.strategy_dictionaries as strategy_dictionaries
 
 ctx = initialise_dictionaries.initialise(fixture_name, config)
 
-initial_n = None
-for candidate_n in (8, 6, 4):
-    name = utilities.get_gamestate_dictionary_name(candidate_n, draft_stage_module.DraftStage.none)
-    if len(ctx.gamestate_dictionaries[name]) > 0:
-        initial_n = candidate_n
-        break
-
-if initial_n is None:
-    raise SystemError("Could not determine initial player count for fixture {}".format(fixture_name))
-
-initial_strategy_dictionary_name = utilities.get_strategy_dictionary_name(
-    initial_n, draft_stage_module.DraftStage.select_defender)
-initial_strategy_dictionary = ctx.strategy_dictionaries[initial_strategy_dictionary_name]
-initial_strategy = utilities.get_arbitrary_dictionary_entry(initial_strategy_dictionary)
+# The top-level strategy is the select_defender game at the initial (full-team)
+# gamestate, recomputed from the solved values (GitHub issue #13, B3).
+initial_n = len(ctx.friendly.names)
+root = game_state_dictionaries.get_initial_game_state(ctx)
+strategy = strategy_dictionaries.game_strategy(ctx, root)
 
 result = {
     "n": initial_n,
-    "friendly": [[ctx.friendly.name(entry[0]), entry[1]] for entry in initial_strategy[0]],
-    "enemy": [[ctx.enemy.name(entry[0]), entry[1]] for entry in initial_strategy[1]],
-    "value": initial_strategy[2],
+    "friendly": [[ctx.friendly.name(entry[0]), entry[1]] for entry in strategy[0]],
+    "enemy": [[ctx.enemy.name(entry[0]), entry[1]] for entry in strategy[1]],
+    "value": strategy[2],
 }
 
 # Isolate the JSON payload with sentinels so any incidental prints from the

--- a/drafter/tests/test_discard_wiring.py
+++ b/drafter/tests/test_discard_wiring.py
@@ -5,14 +5,12 @@ attackers to the child pools, not the attackers who just played. The golden
 tests would catch a regression only as an unexplained value shift; this test
 pins the wiring itself, cell by cell, with sentinel child values.
 
-In-process (post-B2, GitHub issue #13): players are integer indices, pairing
-values are index-keyed numpy arrays on a SolverContext, and get_game_strategy
-is stubbed to capture the payoff matrix -- no solver or global state involved.
+In-process (B3, GitHub issue #13): players are integer indices, pairing values
+are index-keyed numpy arrays, and games.build_discard_game returns the payoff
+matrix directly given a child-value lookup -- no solver or global state involved.
 """
 import numpy as np
-import pytest
 
-import drafter.common.utilities as utilities
 import drafter.solver.games as games
 import drafter.solver.context as context
 from drafter.common.pairing import PairingTables
@@ -32,9 +30,10 @@ def make_ctx(best, worst):
         pairing=PairingTables(best, worst, 0.5),
         restriction=None,
         paths=None,
-        gamestate_dictionaries={},
-        strategy_dictionaries={},
-        game_solution_caches=games.make_game_solution_caches())
+        gamestate_key_arrays={},
+        value_arrays={},
+        draft_strategy_cache={},
+        extension_values={})
 
 
 def child_key(remaining_friends, extra_friend, remaining_enemies, extra_enemy):
@@ -45,7 +44,7 @@ def child_key(remaining_friends, extra_friend, remaining_enemies, extra_enemy):
     ).get_key()
 
 
-def test_discard_attacker_returns_refused_attackers_to_child_pools(monkeypatch):
+def test_discard_attacker_returns_refused_attackers_to_child_pools():
     # 6-player state, mid-draft: defenders picked, attackers presented. Indices
     # per side: defender 0, attacker_A 1, attacker_B 2, remaining 3/4/5.
     f_defender, f_attacker_A, f_attacker_B = 0, 1, 2
@@ -72,15 +71,6 @@ def test_discard_attacker_returns_refused_attackers_to_child_pools(monkeypatch):
         child_key(remaining_friends, f_attacker_A, remaining_enemies, e_attacker_B): 3000.0,
         child_key(remaining_friends, f_attacker_B, remaining_enemies, e_attacker_B): 4000.0,
     }
-    select_defender_strategies = {key: [None, None, value] for key, value in sentinels.items()}
-
-    captured = {}
-
-    def capture_game_strategy(cache, game_array, friendly_options, enemy_options):
-        captured["array"] = game_array
-        return "stub"
-
-    monkeypatch.setattr(utilities, "get_game_strategy", capture_game_strategy)
 
     gamestate = GameState(
         DraftStage.select_attackers,
@@ -88,7 +78,7 @@ def test_discard_attacker_returns_refused_attackers_to_child_pools(monkeypatch):
         TeamPermutation(remaining_enemies, e_defender, e_attacker_A, e_attacker_B),
     )
 
-    assert games.discard_attacker(ctx, 6, gamestate, select_defender_strategies) == "stub"
+    game_array, _, _ = games.build_discard_game(ctx, gamestate, lambda key: sentinels[key])
 
     # Row = enemy attacker the friendly side refuses, column = friendly attacker
     # the enemy side refuses. In each cell the KEPT attackers play the defenders
@@ -100,4 +90,4 @@ def test_discard_attacker_returns_refused_attackers_to_child_pools(monkeypatch):
         [fD_eB + fB_eD + 1000.0, fD_eB + fA_eD + 2000.0],
         [fD_eA + fB_eD + 3000.0, fD_eA + fA_eD + 4000.0],
     ]
-    assert captured["array"].tolist() == expected
+    assert game_array.tolist() == expected

--- a/drafter/tests/test_packing.py
+++ b/drafter/tests/test_packing.py
@@ -63,6 +63,16 @@ def test_draft_stage_of_code(defender, attacker_a, attacker_b, discarded, expect
     assert packing.draft_stage_of_code(code) == expected
 
 
+def test_gamestate_key_round_trip():
+    # A gamestate key stacks the enemy team code above the friendly one; both
+    # must survive the round trip and fit the 48-bit budget.
+    for friendly_code, enemy_code in [(0, 0), (0xABCDEF, 0x123456), (0xFFFFFF, 0),
+                                      (0, 0xFFFFFF), (0xFFFFFF, 0xFFFFFF)]:
+        key = packing.encode_gamestate(friendly_code, enemy_code)
+        assert packing.decode_gamestate(key) == (friendly_code, enemy_code)
+        assert key < (1 << 48)
+
+
 def test_team_permutation_n_counts_remaining_plus_roles():
     # 2 remaining + defender + 2 attackers = 5.
     code = packing.encode_team_permutation(packing.mask_from_indices([6, 7]), 0, 1, 2, None)

--- a/scripts/compute_golden_value.py
+++ b/scripts/compute_golden_value.py
@@ -20,33 +20,19 @@ import drafter.solver.context as context
 fixture_name = sys.argv[1] if len(sys.argv) > 1 else "Smoke"
 k = int(sys.argv[2]) if len(sys.argv) > 2 else 4
 
-config = context.SolverConfig(
-    read_gamestates=False,
-    write_gamestates=False,
-    read_strategies=False,
-    write_strategies=False,
-    restrict_attackers=True,
-    restricted_attackers_count=k)
+config = context.SolverConfig(restrict_attackers=True, restricted_attackers_count=k)
 
 import drafter.data.initialise_dictionaries as initialise_dictionaries
-import drafter.common.utilities as utilities
-import drafter.common.draft_stage as draft_stage_module
+import drafter.solver.game_state_dictionaries as game_state_dictionaries
+import drafter.solver.strategy_dictionaries as strategy_dictionaries
 
 t0 = time.time()
 ctx = initialise_dictionaries.initialise(fixture_name, config)
 print("Total init time: {}s".format(round(time.time() - t0, 2)))
 
-initial_n = 8
-for candidate_n in (8, 6, 4):
-    name = utilities.get_gamestate_dictionary_name(candidate_n, draft_stage_module.DraftStage.none)
-    if len(ctx.gamestate_dictionaries[name]) > 0:
-        initial_n = candidate_n
-        break
-
-initial_strategy_dictionary_name = utilities.get_strategy_dictionary_name(
-    initial_n, draft_stage_module.DraftStage.select_defender)
-initial_strategy_dictionary = ctx.strategy_dictionaries[initial_strategy_dictionary_name]
-initial_strategy = utilities.get_arbitrary_dictionary_entry(initial_strategy_dictionary)
+initial_n = len(ctx.friendly.names)
+root = game_state_dictionaries.get_initial_game_state(ctx)
+initial_strategy = strategy_dictionaries.game_strategy(ctx, root)
 
 print("\nFixture: {}, k={}, n={}".format(fixture_name, k, initial_n))
 print("Top-level value (repr): {!r}".format(initial_strategy[2]))

--- a/scripts/smoke_draft.py
+++ b/scripts/smoke_draft.py
@@ -23,11 +23,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import drafter.solver.context as context
 
 enemy_team_name = sys.argv[1] if len(sys.argv) > 1 else "Smoke"
-config = context.SolverConfig(
-    read_gamestates=False,
-    write_gamestates=False,
-    read_strategies=False,
-    write_strategies=False)
+config = context.SolverConfig()
 random.seed(0)
 
 import drafter.data.initialise_dictionaries as initialise_dictionaries


### PR DESCRIPTION
The RAM step for **#13**. Builds on B2a (#35) / B2b (#36). With B2, Scotland k=3 peaked at ~1816 MB (the packed keys shrank the *keys*, but the ~1.5M `GameState` objects and ~950k strategy vectors stored as dict *values* dominated). B3 stops storing those.

**Result: Scotland k=3 peak working set ~120 MB (down from ~1.8 GB, ~15×) — meets #13's <200 MB criterion.**

## What changed
- **Single-int gamestate keys** (`packing.py`): `friendly | enemy<<24`, so a key fits a numpy int64.
- **Enumeration** (`game_state_dictionaries.enumerate_gamestates`): BFS storing each `(n, stage)` level as a **sorted numpy int64 key array** — no `GameState` objects kept (decoded on demand). The whole tree ≈ 12 MB.
- **Value-only backward induction** (`strategy_dictionaries.initialise_values`): each gamestate's game is built from its children's values (`games.build_game`) and solved for the **value only** (`utilities.get_game_value`). Values live per stage as parallel sorted `(keys, values)` arrays (`StageValues`, binary-search lookup) — ≈ 8 MB vs ~810 MB of strategy vectors. Only the LP solves stay memoised; the per-matrix value cache is dropped (re-solving small games is cheap; caching them cost ~70 MB of peak).
- **Draft** recomputes the labelled strategy for each visited gamestate on demand from child values; the same recursion (`game_value`) solves off-tree, non-k-restricted moves — replacing the old tree-extension machinery.
- **No disk cache**: its JSON format was incompatible with the value arrays and loading it would spend the RAM we're saving. The solve is fast (~28 s) and held in-process for the whole session. #26's user-matches-dir *input* resolution is unchanged; only the (now-unused) cache-dir sub-feature is superseded.
- Removed now-dead helpers (dictionary-name / arbitrary-entry) and the cache config flags.

## Verification
- **Bit-identical values vs `main`**: Smoke `4.997553182223154`, Six `1.9058104884743532`, Scotland k=3 slow test passes (value `5.875946490218083`, supports `{Mariusz}`/`{Drukhari}`); smoke draft output identical.
- **RAM (Scotland k=3, peak working set), 3 runs: 116.6 / 115.9 / 117.2 MB** (was 1816 MB).
- **Enumeration ~8 s** ≤ 16 s; full solve ~28 s.
- Fast suite **88 passed** (adds a gamestate-key round-trip test; `test_discard_wiring` now checks `build_discard_game` directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)