### PR TITLE
M4 #18: web trainer design doc + worker-contract mock

### DIFF
--- a/docs/web-design.md
+++ b/docs/web-design.md
@@ -37,8 +37,10 @@ What the artifact *does* correctly encode, and we keep:
 - Draft state machine: `defender → attackers → refusal → done`, over rounds at
   8/6/4 players, last 4 games auto-resolving.
 - The **value model** (matches PLAN.md workstream C): `best` map value when the friendly
-  side defends, `worst` when the enemy defends, midpoint `(best+worst)/2` for neutral
-  games (refused-vs-refused, last players).
+  side defends, `worst` when the enemy defends, and `worst + w·(best − worst)` for neutral
+  games (refused-vs-refused, last players), where `w = neutral_map_weight` (default
+  **0.5**, i.e. the midpoint — see `drafter/solver/context.py`). Midpoint is the default,
+  not the model; the MVP hardcodes `w = 0.5` (see §7).
 - Bot "styles" (equilibrium / greedy / wildcard), colourblind toggle, undo stack,
   localStorage saves, JSON import/export, paste-from-spreadsheet, simple/advanced mode.
 
@@ -87,7 +89,8 @@ correlate responses. Versioned with `protocol: 1`.
 // Run the full solve for the current matrix. Long-running → emits progress.
 { type: 'solve', reqId, protocol: 1,
   matrix: Matrix,           // see §4.1 — best/worst per cell, internal scale
-  k: number | null }        // k-restriction (null = exact; M3/#5 decides default)
+  k: number | null,         // k-restriction (null = exact; M3/#5 decides default)
+  neutralWeight?: number }  // neutral-game weight w (default 0.5 = midpoint); MVP omits/hardcodes
 
 // Query one draft node (instant; served from the solved values held in the worker).
 { type: 'node', reqId, path: Move[] }   // path from root; [] = opening node
@@ -115,13 +118,16 @@ engine-internal detail; the UI treats `path` as an opaque list it appends to.
 // node() response:
 { type: 'nodeResult', reqId, node: NodeResult }
 
+// reset() ack (reset is not fire-and-forget — the UI awaits confirmation):
+{ type: 'reset-ok', reqId }
+
 { type: 'error', reqId, code: string, message: string }
 ```
 
 ### 3.3 `NodeResult` — the per-node payload the trainer + Why panel consume
 
-This is the shape the UI already expects (the mockup's `{cands, evs, probs, names,
-_pairData}`), restated with **real** semantics:
+This is the shape the UI already expects (illustratively, the mockup's internal
+`cands` / `evs` / `probs` / `names` / `_pairData`), restated with **real** semantics:
 
 ```ts
 type NodeResult = {
@@ -135,8 +141,12 @@ type NodeResult = {
     id: number | [number, number],   // player index, or attacker pair
     name: string | [string, string],
     prob: number,                     // ← EQUILIBRIUM mixed-strategy weight (LP), NOT softmax(ev)
-    ev: number                        // ← continuation value if this choice is taken
-                                      //   (backward-induction value, internal scale)
+    ev: number                        // ← value of the sub-game reached by fixing this choice
+                                      //   against the opponent's equilibrium mix (a row/col
+                                      //   expectation over the payoff matrix). The worker
+                                      //   derives this alongside the strategy; today's
+                                      //   get_game_strategy returns only per-option probs + one
+                                      //   scalar game value, so this is a NEW per-choice field.
   }>,
 
   // "Why" panel: the payoff matrix at this node (child values), so the panel can
@@ -219,7 +229,7 @@ losslessly, tolerates in-progress/invalid edits).
 | Strategy (`prob`) | `softmax(evs)` heuristic | **Nash mixed strategy from the LP** |
 | Why panel | approximate | real payoff matrix (child values) + equilibrium mixes |
 | Bot styles | client-side sampling of a heuristic | client-side sampling of the **true** strategy (unchanged) |
-| Value model | best/worst/midpoint ✓ | best/worst/midpoint ✓ (already correct — keep) |
+| Value model | best/worst; neutral = midpoint ✓ | best/worst; neutral = `worst + w·(best−worst)`, `w`=`neutral_map_weight` (default 0.5 = midpoint) |
 
 The UI's data *shapes* barely change; its *source* changes from "compute inline with a
 heuristic" to "await a message from the worker." This is why Slices 1–3 can be built
@@ -255,8 +265,11 @@ real engine dropped in behind the same contract at Slice 2.
 ### 7.1 The k / engine performance ladder
 
 `k` (the attacker-restriction, `restricted_attackers_count`) is the dominant cost lever:
-the gamestate count fans out **~4× per k-increment** at each select-attackers stage, and
-the 4-player stages already dominate the tree. So:
+each select-attackers step considers only the `k` heuristically-best attackers per side —
+ranked by *advantage vs the specific opposing defender minus average vs the rest*
+(`team_permutation.py`), **not** simply the k globally-best. The gamestate count fans out
+**~4× per k-increment** at each select-attackers stage, and the 4-player stages already
+dominate the tree. So:
 
 - **k=3 — MVP.** Smallest tree; the interactive target that must "feel like seconds."
   Ship the trainer here first.

--- a/docs/web-design.md
+++ b/docs/web-design.md
@@ -1,0 +1,314 @@
+# Web trainer — architecture addendum (issue #18)
+
+**Status:** draft for review (issue #18) · **Date:** 2026-07-05
+
+> **Companion prototype:** a runnable, dependency-free mock of the §3 worker contract
+> lives at [`web/prototypes/contract-mock.html`](../web/prototypes/contract-mock.html).
+> It is throwaway validation that the protocol round-trips — **not** the shipped app.
+
+> This document is the *engineering* half of issue #18. The *UX* half is already
+> answered — completely — by the Claude Design artifact
+> (`WTC Draft Trainer(1).html`). This addendum deliberately does **not** re-describe
+> the screens; it adopts the artifact as the visual/interaction source of truth and
+> specifies only what a visual mockup cannot: the UI↔engine seam, the data formats,
+> the validation rules, and the decisions we are deliberately deferring.
+>
+> It is written to be **independent of the two open decisions** — the compute-engine
+> language (TS vs Rust→WASM, gated on M3 / issue #17) and the frontend framework
+> (React vs Svelte). Nothing here changes based on either.
+
+---
+
+## 1. Relationship to the design artifact
+
+| Question | Answered by |
+|---|---|
+| What does it look like? Screens, layout, flow, colours, copy | **The artifact** (adopt as-is, by reference) |
+| How is it actually built? Worker seam, data contracts, persistence format, validation, slicing | **This doc** |
+
+The artifact is a **throwaway prototype**: its "Solve" is a scripted progress bar, its
+bot is a greedy `argmax` heuristic, and everything runs on the main thread. Those are
+placeholders. This doc records the *real* architecture that replaces them, and — most
+importantly — the **stub→real mapping** (§5) so the intent survives when the prototype
+is rebuilt for production.
+
+What the artifact *does* correctly encode, and we keep:
+- Four screens: **Matrix editor → Solve view → Draft trainer → Draft summary**.
+- Draft state machine: `defender → attackers → refusal → done`, over rounds at
+  8/6/4 players, last 4 games auto-resolving.
+- The **value model** (matches PLAN.md workstream C): `best` map value when the friendly
+  side defends, `worst` when the enemy defends, midpoint `(best+worst)/2` for neutral
+  games (refused-vs-refused, last players).
+- Bot "styles" (equilibrium / greedy / wildcard), colourblind toggle, undo stack,
+  localStorage saves, JSON import/export, paste-from-spreadsheet, simple/advanced mode.
+
+---
+
+## 2. Architecture at a glance
+
+Fully static, client-side, no backend (privacy is mandatory — pairing matrices are
+competitive secrets and must never leave the browser; this also makes free static
+hosting possible). Hosting: **GitHub Pages** (repo already there; Cloudflare Pages is
+the drop-in upgrade if ever needed).
+
+```
+┌─────────────────────────── Browser tab ───────────────────────────┐
+│                                                                    │
+│  UI thread (framework: React|Svelte — TBD)                         │
+│   ├─ Matrix editor        ├─ Draft trainer     ├─ Draft summary    │
+│   ├─ Solve view           └─ Why panel                             │
+│   │                                                                │
+│   │   postMessage(request)          postMessage(event|result)      │
+│   ▼                                        ▲                       │
+│  ┌──────────────── Web Worker (engine: TS|WASM — TBD) ─────────┐   │
+│  │  solve()  → enumerate + backward induction (LP per game)    │   │
+│  │  holds solved values in memory; answers per-node queries    │   │
+│  └─────────────────────────────────────────────────────────────┘  │
+│                                                                    │
+│  localStorage  ◄──── persist() / restore()   (never leaves tab)    │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+The **Web Worker boundary is the whole point**: the UI framework and the engine
+language are chosen independently, because they only ever exchange plain
+(structured-clone-able) JSON messages. Either side can be built against a mock of the
+other.
+
+---
+
+## 3. The engine ⟷ UI contract (worker message protocol)
+
+All messages are plain JSON objects with a `type` discriminator and a `reqId` to
+correlate responses. Versioned with `protocol: 1`.
+
+### 3.1 Requests (UI → worker)
+
+```ts
+// Run the full solve for the current matrix. Long-running → emits progress.
+{ type: 'solve', reqId, protocol: 1,
+  matrix: Matrix,           // see §4.1 — best/worst per cell, internal scale
+  k: number | null }        // k-restriction (null = exact; M3/#5 decides default)
+
+// Query one draft node (instant; served from the solved values held in the worker).
+{ type: 'node', reqId, path: Move[] }   // path from root; [] = opening node
+
+// Discard the solved state (matrix edited → results invalid).
+{ type: 'reset', reqId }
+```
+
+`Move` identifies a decision made walking the tree (which side, stage, chosen
+index/indices), enough for the worker to locate the gamestate. Exact encoding is an
+engine-internal detail; the UI treats `path` as an opaque list it appends to.
+
+### 3.2 Responses & events (worker → UI)
+
+```ts
+// During solve():
+{ type: 'progress', reqId, frac: number,     // 0..1 — drives the REAL progress bar
+  phase: string }                            // e.g. 'enumerating' | 'inducting'
+
+// solve() completed:
+{ type: 'solved', reqId,
+  expected: number,                          // equilibrium expected team result (internal scale)
+  root: NodeResult }                         // opening-defender node (see below)
+
+// node() response:
+{ type: 'nodeResult', reqId, node: NodeResult }
+
+{ type: 'error', reqId, code: string, message: string }
+```
+
+### 3.3 `NodeResult` — the per-node payload the trainer + Why panel consume
+
+This is the shape the UI already expects (the mockup's `{cands, evs, probs, names,
+_pairData}`), restated with **real** semantics:
+
+```ts
+type NodeResult = {
+  stage: 'defender' | 'attackers' | 'refusal' | 'done',
+  side: 'my' | 'enemy' | 'simultaneous',
+  round: 1 | 2 | 3,
+
+  // The candidate choices at this node (single index for defender/refusal;
+  // pairs for attackers).
+  choices: Array<{
+    id: number | [number, number],   // player index, or attacker pair
+    name: string | [string, string],
+    prob: number,                     // ← EQUILIBRIUM mixed-strategy weight (LP), NOT softmax(ev)
+    ev: number                        // ← continuation value if this choice is taken
+                                      //   (backward-induction value, internal scale)
+  }>,
+
+  // "Why" panel: the payoff matrix at this node (child values), so the panel can
+  // show WHERE the ev comes from. Recomputed on demand from stored values (B3).
+  why: {
+    rowLabels: string[], colLabels: string[],
+    payoff: number[][],               // internal scale
+    myStrategy: number[], enStrategy: number[]  // equilibrium mixes over rows/cols
+  } | null
+}
+```
+
+**Bot styles stay in the UI.** `equilibrium` = sample from `choices[].prob`;
+`greedy` = pick `argmax(prob)`; `wildcard` = temperature-flattened sample. These are
+pure client-side transforms of the returned strategy — the engine only ever returns
+the true equilibrium. (In the mockup these live in `sample()`; they stay there.)
+
+### 3.4 Solve view payload
+
+The Solve view shows the expected team result + opening-defender mixed strategy for
+both sides — i.e. `expected` + `root.choices` (my side) plus the enemy's root strategy.
+`solved.root` carries the friendly opening node; the enemy opening mix is included as
+`root.why.enStrategy` (both sides' opening put-up is one simultaneous matrix game).
+
+---
+
+## 4. Data formats
+
+### 4.1 In-memory matrix (what crosses the worker boundary)
+
+```ts
+type Matrix = {
+  n: 4 | 6 | 8,
+  myNames: string[], enemyNames: string[],   // length n, disjoint
+  cells: { best: number, worst: number }[][] // n×n, INTERNAL scale (score − 10, −10..+10)
+}
+```
+
+Conversion between the community 0–20 scale (all human-facing surfaces) and the
+internal deviation scale (`internal = score − 10`) happens in the **UI presentation
+layer only**, exactly as in the Python engine. The worker speaks internal scale.
+
+### 4.2 localStorage (from the artifact — this is the current shape)
+
+Key `wtcDraftTrainer`:
+```jsonc
+{
+  "cb": false,               // colourblind mode
+  "simpleModeV2": true,      // simple/advanced toggle (note: field-rename versioning)
+  "saves": { "<name>": <SavedMatrix>, ... },
+  "current": {               // the working matrix (auto-restored on load)
+    "myTeam": "Norway", "enemyTeam": "Scotland",
+    "myNames": [...], "enemyNames": [...],
+    "cells": [[{ "b": "12", "w": "9" }, ...], ...]   // strings (as typed), 0–20 scale
+  }
+}
+```
+Note: the artifact stores cells as **0–20 strings** (raw editor input). Normalisation to
+numbers + internal scale happens on solve, not on save. Keep it that way (round-trips
+losslessly, tolerates in-progress/invalid edits).
+
+### 4.3 Export/import file (JSON only for MVP)
+
+**Decided (2026-07-05): JSON-only for the MVP.** CSV interop is deferred.
+- **Native JSON export** — a `SavedMatrix` (the `current` block above) plus a
+  `"format": "wtc-matrix", "version": 1` header. Human-portable, re-importable.
+- **Deferred (post-MVP):** round-trip with the repo's `pairing_matrix_best.csv` +
+  `pairing_matrix_worst.csv` so captains can move a matrix between the CLI and the web
+  app. Nice-to-have; not required for the train-against-the-bot MVP. Revisit if users ask.
+
+---
+
+## 5. Stub → real engine mapping (the crux)
+
+| Concern | Artifact (throwaway) | Real engine (this contract) |
+|---|---|---|
+| Where compute runs | main thread | **Web Worker** |
+| Progress bar | scripted `setInterval` + canned messages | **real `progress` events** (`frac`, `phase`) |
+| Node values (`ev`) | greedy `argmax` simulation (`simAll`/`evDef`…) | **backward-induction values** |
+| Strategy (`prob`) | `softmax(evs)` heuristic | **Nash mixed strategy from the LP** |
+| Why panel | approximate | real payoff matrix (child values) + equilibrium mixes |
+| Bot styles | client-side sampling of a heuristic | client-side sampling of the **true** strategy (unchanged) |
+| Value model | best/worst/midpoint ✓ | best/worst/midpoint ✓ (already correct — keep) |
+
+The UI's data *shapes* barely change; its *source* changes from "compute inline with a
+heuristic" to "await a message from the worker." This is why Slices 1–3 can be built
+against a **mock worker** that returns the heuristic (or canned) `NodeResult`s, with the
+real engine dropped in behind the same contract at Slice 2.
+
+---
+
+## 6. Validation rules (mirror the CLI; run in the UI before `solve`)
+
+- Every cell: `best ≥ worst` (reject otherwise).
+- Cells accept **0–20 numbers** or legacy tokens `--,-,0,+,++`. A bare `0` is the legacy
+  *even* token (10–10), **not** the score 0 — write `0.0` for a 20–0 blowout loss.
+  Numbers outside 0–20 are rejected.
+- Friendly and enemy names disjoint and non-empty.
+- Square matrix; `n ∈ {4, 6, 8}`.
+- Validation is a UI concern (immediate inline feedback, as the artifact already does);
+  the worker assumes a clean `Matrix`.
+
+---
+
+## 7. Deferred decisions & open questions
+
+| Decision | Status | Trigger / owner |
+|---|---|---|
+| **Compute-engine language** (TS vs Rust→WASM) | **Deferred** | After M3 lands; issue #17 spike measures TS-in-browser against real profile numbers. **Benchmark at the target k (4, ideally 5) — not just k=3** — since that's what decides whether TS suffices or Rust→WASM is needed (§7.1). Default TS; Rust→WASM is the escape hatch behind the same contract. Pyodide = dev-only oracle. |
+| **Frontend framework** (React vs Svelte) | **Open, low-stakes** | Decide at Slice 1. Artifact is React (continuity); Claude Design can re-emit in Svelte if chosen. Does not affect this contract. |
+| **Hosting** | **Settled** | GitHub Pages; Cloudflare Pages as upgrade. |
+| **Repo layout** | **Settled (2026-07-05): `web/` subdir of this repo** | Monorepo — see §9. Deploy = Action builds `web/`, base path `/40k-WTC-Draft-Solver/`, `.nojekyll`. |
+| **CSV interop** | **Settled (2026-07-05): deferred** | MVP is JSON-only (§4.3). CSV round-trip revisited post-MVP if asked. |
+| **k (attacker restriction)** | **MVP: k=3 · target: k=4 · stretch: k=5** | k = number of best attackers considered per side (**not** team size). See §7.1 — the main pressure on the engine choice. |
+
+### 7.1 The k / engine performance ladder
+
+`k` (the attacker-restriction, `restricted_attackers_count`) is the dominant cost lever:
+the gamestate count fans out **~4× per k-increment** at each select-attackers stage, and
+the 4-player stages already dominate the tree. So:
+
+- **k=3 — MVP.** Smallest tree; the interactive target that must "feel like seconds."
+  Ship the trainer here first.
+- **k=4 — the real goal.** Today ~15 min / ~2 GB in *native* Python (pre-M3). Only
+  realistic in a browser tab **after** M3's B2/B3 cut RAM to tens of MB and B1 drops
+  solve time to seconds.
+- **k=5 — stretch.** Several × heavier again; likely needs both the full M3 wins **and**
+  the fast (Rust→WASM) engine. Treat as "if we get it fast enough," not a commitment.
+
+Implication for issue #17: the spike must benchmark the **TS engine at k=4 (and probe
+k=5)**, not just k=3 — passing at k=3 says nothing about whether TS clears the real goal.
+This is the concrete trigger that would flip the engine choice from TS to Rust→WASM.
+
+---
+
+## 8. How this slices (issues #19 / #20 / #21)
+
+- **#19 Matrix editor** — needs §4 (formats) + §6 (validation). **No engine.** Fully
+  buildable now once the framework is picked; can ship to Pages behind a beta flag.
+- **#20 Solve + strategy tables** — needs §3 (contract) + §5. Built against a **mock
+  worker** first; real engine dropped in when M3 + #17 land.
+- **#21 Full trainer** — needs the full `NodeResult` (§3.3) incl. the Why panel.
+
+Everything in §3–§6 is decidable and buildable-against-a-mock **now**; only the engine
+*implementation* waits on M3, and only the *framework* waits on a preference call.
+
+---
+
+## 9. Repo layout (decided 2026-07-05)
+
+The web app lives in a **`web/` subdirectory of this repo** (monorepo), not a separate
+repo. Rationale: the TS port must stay in lockstep with the Python engine's rules and be
+validated against conformance fixtures generated from it, so one source of truth, one
+issue tracker/milestone set (M4 is already here), and atomic cross-cutting changes win.
+A separate repo would only pay off if the web app became its own product with its own
+contributors — not the case for a solo maintainer.
+
+```
+40k-WTC-Draft-Solver/
+├─ drafter/                     # existing Python package (untouched)
+├─ docs/web-design.md           # this addendum, migrated from scratchpad
+├─ web/                         # the web app (self-contained)
+│  ├─ package.json, vite config, src/, ...
+│  └─ (node_modules/, dist/ — gitignored)
+└─ .github/workflows/
+   ├─ ci.yml                    # existing Python CI (unchanged)
+   └─ deploy-pages.yml          # new: build web/ → publish to Pages
+```
+
+Deploy implications (all standard):
+- The Pages Action builds inside `web/` and publishes its `dist/`.
+- Vite `base` = `/40k-WTC-Draft-Solver/` (project-site path), or `/` behind a custom domain.
+- Add an empty `.nojekyll` to the published output.
+- Add `web/node_modules/` and `web/dist/` to `.gitignore`.
+- Python CI and the Pages deploy are independent jobs; neither blocks the other.

--- a/web/prototypes/README.md
+++ b/web/prototypes/README.md
@@ -1,0 +1,28 @@
+# web/prototypes
+
+Throwaway spikes that validate design decisions **before** the real web app exists.
+Nothing here ships; none of it commits us to a framework or build tool.
+
+## `contract-mock.html`
+
+A self-contained, dependency-free validation of the **§3 UI⟷engine worker contract**
+from [`../../docs/web-design.md`](../../docs/web-design.md). It runs the message
+protocol end-to-end: the page (UI thread) posts `solve`/`node`/`reset`, and a real Web
+Worker — built from an inline Blob — replies with `progress` events, then `solved` /
+`nodeResult` / `error`. The worker's math is a **stub heuristic** (softmax over
+per-choice values), not the real solver; its only purpose is to prove the *contract*
+round-trips and yields well-formed `NodeResult`s.
+
+On load it runs a **self-test** and shows a PASS/FAIL banner (details in the browser
+console).
+
+### Run it
+
+Web Workers need an http origin (not `file://`). From the repo root:
+
+```
+python -m http.server 8137
+# open http://localhost:8137/web/prototypes/contract-mock.html
+```
+
+Expect: `SELF-TEST: PASS ✓`.

--- a/web/prototypes/contract-mock.html
+++ b/web/prototypes/contract-mock.html
@@ -184,6 +184,7 @@ function request(msg, onProgress) {
 }
 const solve = (matrix, k, onProgress) => request({ type: 'solve', protocol: 1, matrix, k }, onProgress);
 const node  = (path)               => request({ type: 'node', path });
+const reset = ()                   => request({ type: 'reset' });
 
 /* ------------------------------------------------------------------ *
  * Helpers: a demo matrix, shape validators, DOM logging.
@@ -282,6 +283,11 @@ document.getElementById('nodeBtn').onclick = async () => {
       validateNodeResult(r.node, 'node@' + depth + ' (' + r.node.stage + ')');
       log('node(depth=' + depth + '): stage=' + r.node.stage + ', choices=' + r.node.choices.length);
     }
+
+    // 2b. reset() acks through the contract (not fire-and-forget).
+    const rst = await reset();
+    assert(rst.type === 'reset-ok', 'reset() -> reset-ok');
+    log('reset(): ' + rst.type);
 
     // 3. errors surface through the contract (query before solve on a fresh worker).
     const w2 = new Worker(URL.createObjectURL(new Blob([WORKER_SRC], { type: 'application/javascript' })));

--- a/web/prototypes/contract-mock.html
+++ b/web/prototypes/contract-mock.html
@@ -1,0 +1,309 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>WTC trainer — worker contract mock (§3 validation)</title>
+<style>
+  :root { color-scheme: dark; }
+  body { margin: 0; font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+         background: #101418; color: #cfd6de; padding: 24px; }
+  h1 { font-size: 18px; margin: 0 0 4px; }
+  .sub { color: #6b7480; margin: 0 0 20px; }
+  #banner { font-weight: 700; padding: 10px 16px; border-radius: 8px; margin: 0 0 20px;
+            display: inline-block; }
+  .pass { background: #16351f; color: #45c48f; border: 1px solid #2c6b41; }
+  .fail { background: #2a1215; color: #ff8a80; border: 1px solid #5c2b2e; }
+  .run  { background: #1a2530; color: #4e9af1; border: 1px solid #24435f; }
+  section { background: #161b20; border: 1px solid #ffffff14; border-radius: 12px;
+            padding: 16px 18px; margin: 0 0 16px; max-width: 720px; }
+  button { background: #4e9af1; color: #101418; border: 0; border-radius: 8px;
+           padding: 8px 14px; font-weight: 600; cursor: pointer; }
+  button:disabled { opacity: .5; cursor: default; }
+  .bar { height: 8px; background: #ffffff14; border-radius: 4px; overflow: hidden; margin: 10px 0; }
+  .bar > i { display: block; height: 100%; width: 0; background: #4e9af1; transition: width .1s; }
+  table { border-collapse: collapse; width: 100%; margin-top: 8px; }
+  th, td { text-align: left; padding: 4px 8px; border-bottom: 1px solid #ffffff10; }
+  th { color: #6b7480; font-weight: 600; font-size: 12px; text-transform: uppercase; }
+  .prob { color: #45c48f; }
+  pre#log { background: #0b0e11; border: 1px solid #ffffff10; border-radius: 8px;
+            padding: 12px; max-width: 720px; overflow: auto; font-size: 12px;
+            color: #8b95a1; white-space: pre-wrap; }
+  code { color: #e0b055; }
+</style>
+</head>
+<body>
+  <h1>WTC trainer — worker contract mock</h1>
+  <p class="sub">Throwaway validation of the §3 UI&#8596;engine protocol from
+     <code>docs/web-design.md</code>. The "engine" is a real Web Worker running a
+     <b>stub heuristic</b> (softmax over per-choice values) — <b>not</b> the real solver.
+     Its only job is to prove the message contract round-trips and yields well-formed
+     <code>NodeResult</code>s.</p>
+
+  <div id="banner" class="run">SELF-TEST: running…</div>
+
+  <section>
+    <div style="display:flex;gap:10px;align-items:center;">
+      <button id="solveBtn">Run solve</button>
+      <button id="nodeBtn" disabled>Query a draft node</button>
+      <span id="expected" style="margin-left:auto;color:#6b7480;"></span>
+    </div>
+    <div class="bar"><i id="prog"></i></div>
+    <div id="phase" style="color:#6b7480;font-size:12px;min-height:16px;"></div>
+    <div id="table"></div>
+  </section>
+
+  <pre id="log"></pre>
+
+<script>
+/* ------------------------------------------------------------------ *
+ * The mock ENGINE, as a real Web Worker built from a Blob so the file
+ * stays self-contained. Implements the §3 message protocol exactly.
+ * ------------------------------------------------------------------ */
+const WORKER_SRC = `
+'use strict';
+let MATRIX = null, K = null;
+
+const softmax = (xs, t) => {
+  const mx = Math.max(...xs);
+  const ex = xs.map(v => Math.exp((v - mx) / t));
+  const s = ex.reduce((a, b) => a + b, 0);
+  return ex.map(v => v / s);
+};
+// value model (doc §1/§4): friendly defends -> best, enemy defends -> worst,
+// neither -> midpoint. Internal scale.
+const midpoint = c => (c.best + c.worst) / 2;
+
+function rootNode() {
+  const n = MATRIX.n, cells = MATRIX.cells;
+  // per-defender stand-in EV: mean midpoint value across enemy pool (STUB math)
+  const evs = [];
+  for (let i = 0; i < n; i++) {
+    let s = 0; for (let j = 0; j < n; j++) s += cells[i][j].best;
+    evs.push(s / n);
+  }
+  const probs = softmax(evs, 1.5);
+  const choices = MATRIX.myNames.map((name, i) => ({ id: i, name, prob: probs[i], ev: evs[i] }))
+                                .sort((a, b) => b.prob - a.prob);
+  // why panel: opening put-up is one matrix game (my defenders x enemy defenders)
+  const payoff = cells.map(row => row.map(midpoint));
+  const rowMeans = payoff.map(r => r.reduce((a, b) => a + b, 0) / n);
+  const colMeans = payoff[0].map((_, j) => payoff.reduce((a, r) => a + r[j], 0) / n);
+  return {
+    stage: 'defender', side: 'simultaneous', round: 1, choices,
+    why: {
+      rowLabels: MATRIX.myNames, colLabels: MATRIX.enemyNames, payoff,
+      myStrategy: softmax(rowMeans, 1.5),
+      enStrategy: softmax(colMeans.map(v => -v), 1.5)
+    }
+  };
+}
+
+function nodeFor(path) {
+  // Stage cycles with path depth so the round-trip exercises each stage shape.
+  const stages = ['defender', 'attackers', 'refusal'];
+  const stage = stages[(path.length) % 3];
+  const n = MATRIX.n;
+  const names = MATRIX.myNames.slice(0, Math.max(2, n - path.length));
+  let choices;
+  if (stage === 'attackers') {
+    // pair choices
+    const pairs = [];
+    for (let a = 0; a < names.length; a++)
+      for (let b = a + 1; b < names.length; b++) pairs.push([a, b]);
+    const evs = pairs.map(([a, b]) => (a === b ? 0 : (names.length - a - b)));
+    const probs = softmax(evs, 1.5);
+    choices = pairs.map((p, i) => ({
+      id: p, name: [names[p[0]], names[p[1]]], prob: probs[i], ev: evs[i]
+    })).sort((x, y) => y.prob - x.prob);
+  } else {
+    const evs = names.map((_, i) => names.length - i);
+    const probs = softmax(evs, 1.5);
+    choices = names.map((name, i) => ({ id: i, name, prob: probs[i], ev: evs[i] }))
+                   .sort((a, b) => b.prob - a.prob);
+  }
+  return { stage, side: 'my', round: Math.min(1 + path.length, 3), choices, why: null };
+}
+
+self.onmessage = (e) => {
+  const m = e.data;
+  try {
+    if (m.type === 'solve') {
+      if (!m.matrix || !m.matrix.cells) throw { code: 'BAD_MATRIX', message: 'missing cells' };
+      MATRIX = m.matrix; K = m.k;
+      const steps = [
+        [0.25, 'enumerating'], [0.55, 'inducting'], [0.85, 'inducting'], [1.0, 'polishing']
+      ];
+      let i = 0;
+      const tick = () => {
+        const [frac, phase] = steps[i++];
+        self.postMessage({ type: 'progress', reqId: m.reqId, frac, phase });
+        if (i < steps.length) { setTimeout(tick, 60); return; }
+        const root = rootNode();
+        const expected = root.why.payoff
+          .reduce((a, r) => a + r.reduce((x, y) => x + y, 0), 0) / (MATRIX.n * MATRIX.n);
+        self.postMessage({ type: 'solved', reqId: m.reqId, expected, root });
+      };
+      setTimeout(tick, 60);
+    } else if (m.type === 'node') {
+      if (!MATRIX) throw { code: 'NOT_SOLVED', message: 'call solve first' };
+      self.postMessage({ type: 'nodeResult', reqId: m.reqId, node: nodeFor(m.path || []) });
+    } else if (m.type === 'reset') {
+      MATRIX = null; K = null;
+      self.postMessage({ type: 'reset-ok', reqId: m.reqId });
+    } else {
+      throw { code: 'UNKNOWN_TYPE', message: m.type };
+    }
+  } catch (err) {
+    self.postMessage({ type: 'error', reqId: m.reqId,
+      code: err.code || 'ERR', message: err.message || String(err) });
+  }
+};
+`;
+
+/* ------------------------------------------------------------------ *
+ * UI-thread client: correlate reqIds, forward progress, await result.
+ * ------------------------------------------------------------------ */
+const worker = new Worker(URL.createObjectURL(new Blob([WORKER_SRC], { type: 'application/javascript' })));
+let nextReq = 1;
+const pending = new Map();
+worker.onmessage = (e) => {
+  const m = e.data;
+  const p = pending.get(m.reqId);
+  if (!p) return;
+  if (m.type === 'progress') { p.onProgress && p.onProgress(m); return; }
+  pending.delete(m.reqId);
+  (m.type === 'error') ? p.reject(new Error(m.code + ': ' + m.message)) : p.resolve(m);
+};
+function request(msg, onProgress) {
+  const reqId = nextReq++;
+  return new Promise((resolve, reject) => {
+    pending.set(reqId, { resolve, reject, onProgress });
+    worker.postMessage({ ...msg, reqId });
+  });
+}
+const solve = (matrix, k, onProgress) => request({ type: 'solve', protocol: 1, matrix, k }, onProgress);
+const node  = (path)               => request({ type: 'node', path });
+
+/* ------------------------------------------------------------------ *
+ * Helpers: a demo matrix, shape validators, DOM logging.
+ * ------------------------------------------------------------------ */
+const log = (...a) => {
+  const el = document.getElementById('log');
+  el.textContent += a.join(' ') + '\n';
+  console.log(...a);
+};
+function demoMatrix(n = 8) {
+  const myNames = Array.from({ length: n }, (_, i) => 'My' + (i + 1));
+  const enemyNames = Array.from({ length: n }, (_, i) => 'En' + (i + 1));
+  const cells = [];
+  for (let i = 0; i < n; i++) {
+    const row = [];
+    for (let j = 0; j < n; j++) {
+      const base = (i - j) * 0.8;               // deterministic, internal scale (-10..10)
+      row.push({ best: Math.round(base + 2), worst: Math.round(base - 2) });
+    }
+    cells.push(row);
+  }
+  return { n, myNames, enemyNames, cells };
+}
+function assert(cond, msg) { if (!cond) throw new Error('ASSERT FAILED: ' + msg); }
+function validateNodeResult(nr, label) {
+  assert(nr && typeof nr === 'object', label + ': is object');
+  assert(['defender', 'attackers', 'refusal', 'done'].includes(nr.stage), label + ': valid stage');
+  assert(['my', 'enemy', 'simultaneous'].includes(nr.side), label + ': valid side');
+  assert(Array.isArray(nr.choices) && nr.choices.length > 0, label + ': non-empty choices');
+  let psum = 0;
+  for (const c of nr.choices) {
+    assert('id' in c && 'name' in c, label + ': choice has id+name');
+    assert(typeof c.prob === 'number' && c.prob >= 0, label + ': choice prob >= 0');
+    assert(typeof c.ev === 'number', label + ': choice ev numeric');
+    psum += c.prob;
+  }
+  assert(Math.abs(psum - 1) < 1e-6, label + ': probs sum to 1 (got ' + psum.toFixed(6) + ')');
+  assert(nr.why === null || (Array.isArray(nr.why.payoff)), label + ': why is null or has payoff');
+}
+
+/* ------------------------------------------------------------------ *
+ * Interactive demo wiring.
+ * ------------------------------------------------------------------ */
+let solvedOnce = false;
+function renderStrategy(title, choices) {
+  const rows = choices.slice(0, 8).map(c => {
+    const nm = Array.isArray(c.name) ? c.name.join(' + ') : c.name;
+    return '<tr><td>' + nm + '</td><td class="prob">' + (c.prob * 100).toFixed(1) +
+           '%</td><td>' + c.ev.toFixed(2) + '</td></tr>';
+  }).join('');
+  document.getElementById('table').innerHTML =
+    '<table><thead><tr><th>' + title + '</th><th>Prob</th><th>EV</th></tr></thead><tbody>' +
+    rows + '</tbody></table>';
+}
+document.getElementById('solveBtn').onclick = async () => {
+  const bar = document.getElementById('prog'), ph = document.getElementById('phase');
+  const res = await solve(demoMatrix(8), 3, (p) => {
+    bar.style.width = (p.frac * 100) + '%'; ph.textContent = 'phase: ' + p.phase;
+  });
+  document.getElementById('expected').textContent = 'expected team result: ' + res.expected.toFixed(2);
+  renderStrategy('Opening defender', res.root.choices);
+  document.getElementById('nodeBtn').disabled = false;
+  solvedOnce = true;
+};
+document.getElementById('nodeBtn').onclick = async () => {
+  const r = await node([{ side: 'my', stage: 'defender', choice: 0 }]);
+  renderStrategy('Node (' + r.node.stage + ')', r.node.choices);
+};
+
+/* ------------------------------------------------------------------ *
+ * SELF-TEST on load — the actual verification.
+ * ------------------------------------------------------------------ */
+(async function selfTest() {
+  const banner = document.getElementById('banner');
+  try {
+    log('— self-test start —');
+
+    // 1. solve() streams progress then returns a well-formed solved message.
+    const progress = [];
+    const solved = await solve(demoMatrix(8), 3, (p) => progress.push(p));
+    assert(progress.length > 0, 'received >=1 progress event');
+    for (const p of progress) assert(p.frac >= 0 && p.frac <= 1, 'progress.frac in [0,1]');
+    assert(progress[progress.length - 1].frac === 1, 'progress ends at frac=1');
+    assert(solved.type === 'solved', 'terminal message is "solved"');
+    assert(typeof solved.expected === 'number', 'solved.expected is numeric');
+    validateNodeResult(solved.root, 'root');
+    assert(solved.root.why && solved.root.why.payoff.length === 8, 'root.why has 8x8 payoff');
+    log('solve(): ' + progress.length + ' progress events, expected=' +
+        solved.expected.toFixed(2) + ', root choices=' + solved.root.choices.length);
+
+    // 2. node() returns a well-formed NodeResult for each stage shape.
+    for (let depth = 0; depth < 3; depth++) {
+      const path = Array.from({ length: depth }, () => ({ side: 'my', stage: 'x', choice: 0 }));
+      const r = await node(path);
+      assert(r.type === 'nodeResult', 'node() -> nodeResult (depth ' + depth + ')');
+      validateNodeResult(r.node, 'node@' + depth + ' (' + r.node.stage + ')');
+      log('node(depth=' + depth + '): stage=' + r.node.stage + ', choices=' + r.node.choices.length);
+    }
+
+    // 3. errors surface through the contract (query before solve on a fresh worker).
+    const w2 = new Worker(URL.createObjectURL(new Blob([WORKER_SRC], { type: 'application/javascript' })));
+    const errSeen = await new Promise((resolve) => {
+      w2.onmessage = (e) => resolve(e.data);
+      w2.postMessage({ type: 'node', reqId: 1, path: [] });
+    });
+    assert(errSeen.type === 'error' && errSeen.code === 'NOT_SOLVED', 'error surfaces for node-before-solve');
+    w2.terminate();
+    log('error path: got ' + errSeen.code + ' as expected');
+
+    log('— self-test PASS —');
+    banner.textContent = 'SELF-TEST: PASS ✓  (contract round-trips; NodeResults well-formed)';
+    banner.className = 'pass';
+    console.log('SELF-TEST: PASS');
+  } catch (err) {
+    log('— self-test FAIL —\n' + (err && err.stack || err));
+    banner.textContent = 'SELF-TEST: FAIL ✗  ' + (err.message || err);
+    banner.className = 'fail';
+    console.error('SELF-TEST: FAIL', err);
+  }
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
Lands the **engineering half of the web design doc** (issue #18) plus a runnable
validation of its central contract. Pure planning + a throwaway spike — **no
production app code, and no commitment to the engine language or frontend framework.**

## What's here

**`docs/web-design.md`** — the architecture the visual mockup can't show. It adopts the
Claude Design artifact as the UX source of truth (deliberately does *not* re-describe the
screens) and specifies:

- **§3** the UI⟷engine **Web Worker contract** — `solve`/`node`/`reset` requests,
  `progress`/`solved`/`nodeResult`/`error` responses, and the per-node `NodeResult`
  shape the trainer + "Why" panel consume.
- **§4** in-memory matrix, the localStorage schema (extracted from the artifact), and
  export/import — **JSON-only for the MVP** (CSV interop deferred).
- **§5** the **stub→real engine mapping**: the mockup's fake progress bar + greedy
  `softmax(evs)` heuristic → real progress events + Nash mixed strategy + backward
  induction. Same shapes, real semantics. Bot styles stay client-side.
- **§6** validation rules mirroring the CLI (best ≥ worst, 0–20/legacy tokens, the
  `0` vs `0.0` quirk, square 4/6/8).
- **§7** the deferred-decision register + the **k / engine performance ladder**
  (MVP k=3 · target k=4 · stretch k=5), with the consequence that #17's spike must
  benchmark at k=4/k=5, not just k=3.
- **§9** the **`web/` monorepo layout** and GitHub Pages deploy notes.

**`web/prototypes/contract-mock.html`** — a self-contained, dependency-free proof the
§3 protocol round-trips: a real Blob Web Worker (stub heuristic, *not* the solver)
answers the full message set. An on-load self-test asserts the round-trip, per-stage
`NodeResult` shapes, probability normalisation, and the error path.

## Verification

Ran the mock in-browser (served via `python -m http.server`): **`SELF-TEST: PASS ✓`** —
4 progress events → `solved` (defender, 8 choices); `node()` at depths 0/1/2 →
defender(8) / attackers(21) / refusal(6); `NOT_SOLVED` error surfaces for node-before-solve.

## Deliberately deferred (not blocked by this PR)

- **Engine language** (TS vs Rust→WASM) — after M3 lands; issue #17.
- **Frontend framework** (React vs Svelte) — a preference call at Slice 1 (#19).

Closes #18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
