### PR TITLE
Default to exact solve; k=3 as opt-in fast preview (#16)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,10 +108,17 @@ best when neither does (refused-vs-refused and last-players games).
   arrays (above) cut Scotland k=3 **peak RAM from ~1.8 GB to ~120 MB** (~15×);
   fresh solve ≈ 28 s (enumeration ~8 s, values ~20 s). The old 630 MB JSON disk
   cache is gone — the in-memory solve is fast and cheap enough not to need it.
-- `restricted_attackers_count` (k) in `SolverConfig` (drafter/solver/context.py) is the only current knob:
-  each select-attackers step only considers the k heuristically best
-  attackers per side (heuristic: advantage vs defender minus average vs
-  the rest). k=4 default, k=3 for quick runs.
+- **B5 (decided, issue #16):** the exact (unrestricted) solve lands at ~3 min
+  / <1 GB — under the ~10-min bar — so the CLI **defaults to exact**
+  (`SolverConfig.restrict_attackers=False`), the true equilibrium with no
+  heuristic anywhere. The k-restriction is now an opt-in **fast preview**:
+  `restrict_attackers=True` restricts each select-attackers step to the
+  `restricted_attackers_count` heuristically best attackers per side (heuristic:
+  advantage vs defender minus average vs the rest), and `restricted_attackers_count`
+  defaults to 3 (~30 s at 8 players). `python -m drafter` offers exact-vs-preview
+  as a startup prompt (drafter/data/set_solve_mode.py). The restriction saturates
+  from the bottom up (k≥3 → 4-player stage exact, k≥5 → 6-player, k≥7 → whole
+  draft exact), so k=7 ≡ exact.
 
 ## Input format
 
@@ -154,7 +161,7 @@ changes.
 python -m venv .venv                 # Python 3.12
 ./.venv/Scripts/Activate.ps1         # or ./.venv/Scripts/activate.bat (cmd)
 pip install -e ".[dev]"
-python -m drafter                    # pick opponent folder from the menu
+python -m drafter                    # pick opponent, then exact vs fast-preview solve mode
 ```
 
 `pip install -e ".[dev]"` also installs a `drafter` console script (same
@@ -163,8 +170,9 @@ drafter` work too.
 
 Notes for agents:
 
-- The InquirerPy team menu needs a real TTY. To drive the program
-  non-interactively, build a `SolverConfig` and call
+- The InquirerPy team menu and solve-mode prompt (`set_solve_mode`) need a
+  real TTY. To drive the program non-interactively, build a `SolverConfig`
+  yourself (bypassing the mode prompt) and call
   `ctx = initialise_dictionaries.initialise(enemy_team_name, config)` +
   `draft_loop.play(ctx)`; the in-draft prompts are plain `input()` and accept
   piped lines (empty line = accept suggested move). See `scripts/smoke_draft.py`.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,19 @@
 
 Creates optimal strategies for WTC pairing drafts using game theoretic Nash equilibria.
 
-#### Disclaimer
+#### Solve modes
 
-> By default has long runtime (typically more than an hour). Change the `restricted_attackers_count` default in `SolverConfig` (`drafter/solver/context.py`) from 4 to 3 for more reasonable runtime (typically around 15 minutes).
+At startup (after picking the opponent) you choose a solve mode:
+
+- **Exact** (default) — the true equilibrium, no heuristic. A full 8-player
+  team takes roughly 3 minutes and under 1 GB of RAM; smaller teams finish in
+  seconds.
+- **Fast preview** — a k=3 attacker-restriction heuristic (~30 s at 8 players)
+  for quick iteration. It approximates: it can miss equilibrium attackers, so
+  use exact for the real draft.
+
+(The mode is the `restrict_attackers` / `restricted_attackers_count` pair in
+`SolverConfig`, `drafter/solver/context.py`, if you drive the solver in code.)
 
 ## Input data
 

--- a/drafter/app.py
+++ b/drafter/app.py
@@ -1,12 +1,12 @@
 import drafter.data.set_enemy_team as set_enemy_team  # local source
+import drafter.data.set_solve_mode as set_solve_mode
 import drafter.data.initialise_dictionaries as initialise_dictionaries
-import drafter.solver.context as context
 import drafter.solver.draft_loop as draft_loop
 
 
 def run():
     enemy_team_name = set_enemy_team.prompt_enemy_team()
-    config = context.SolverConfig()
+    config = set_solve_mode.prompt_solve_mode()
     ctx = initialise_dictionaries.initialise(enemy_team_name, config)
     draft_loop.play(ctx)
     exit()

--- a/drafter/data/set_solve_mode.py
+++ b/drafter/data/set_solve_mode.py
@@ -1,0 +1,33 @@
+from InquirerPy import inquirer  # 3rd party packages
+
+import drafter.solver.context as context  # local source
+
+
+# The k the "fast preview" uses. The exact solve is unrestricted; the preview
+# restricts each select-attackers step to the 3 heuristically best attackers per
+# side (PLAN.md B5 decision, GitHub issue #16).
+PREVIEW_K = 3
+
+EXACT_CHOICE = "Exact - true equilibrium (full 8-player solve ~3 min)"
+PREVIEW_CHOICE = "Fast preview - k={} heuristic (~30 s)".format(PREVIEW_K)
+
+
+def config_for_mode(preview):
+    """Build the SolverConfig for the chosen solve mode. Pure (no I/O) so the
+    mapping can be unit-tested without a TTY; prompt_solve_mode does the I/O."""
+    if preview:
+        return context.SolverConfig(restrict_attackers=True, restricted_attackers_count=PREVIEW_K)
+    return context.SolverConfig()  # exact (unrestricted) default
+
+
+def prompt_solve_mode():
+    """Ask whether to run the exact solve (default) or the fast k=3 preview,
+    returning the matching SolverConfig. Mirrors set_enemy_team's InquirerPy
+    startup prompt."""
+    choice = inquirer.select(
+        message="Solve mode:",
+        choices=[EXACT_CHOICE, PREVIEW_CHOICE],
+        default=EXACT_CHOICE,
+    ).execute()
+
+    return config_for_mode(preview=(choice == PREVIEW_CHOICE))

--- a/drafter/solver/context.py
+++ b/drafter/solver/context.py
@@ -28,7 +28,9 @@ class NameIndex:
 # All the knobs that used to live as mutable module-level globals in
 # drafter/data/settings.py. Frozen so a solve can't silently mutate its own
 # configuration mid-run; build a new one to change a knob (GitHub issue #13,
-# B2 solver-context refactor). Defaults match the old settings.py values.
+# B2 solver-context refactor). Defaults match the old settings.py values,
+# except the attacker-restriction knobs below, which default to the exact
+# solve per the B5 decision (GitHub issue #16).
 @dataclass(frozen=True)
 class SolverConfig:
     friendly_team_name: str = "Norway"
@@ -43,11 +45,17 @@ class SolverConfig:
     # to the best-map value. 0.5 = midpoint, a 50/50 model of who ends up with
     # map advantage (PLAN.md workstream C).
     neutral_map_weight: float = 0.5
-    # Maximum number of attacker players considered by each team in each select
-    # attackers step. Default 4. Decrease to 3 for shorter runtime, increase to
-    # 5 for better precision.
-    restrict_attackers: bool = True
-    restricted_attackers_count: int = 4
+    # Attacker-restriction heuristic. OFF by default: the CLI runs the exact,
+    # fully unrestricted solve -- the true equilibrium (B5 decision, issue #16;
+    # ~3 min / <1 GB for a full 8-player team, seconds for smaller). Set
+    # restrict_attackers=True to trade precision for speed: each select-attackers
+    # step then considers only the restricted_attackers_count heuristically best
+    # attackers per side. restricted_attackers_count=3 is the documented fast
+    # preview (~30 s at 8 players), so a bare restrict_attackers=True IS that
+    # preview; the CLI exposes exact-vs-preview as a startup prompt
+    # (drafter/data/set_solve_mode.py).
+    restrict_attackers: bool = False
+    restricted_attackers_count: int = 3
 
 
 # Everything one solve run needs, passed around explicitly instead of read from

--- a/drafter/tests/test_solve_mode.py
+++ b/drafter/tests/test_solve_mode.py
@@ -1,0 +1,37 @@
+"""Solve-mode selection tests (GitHub issue #16).
+
+Guards the exact-by-default decision (PLAN.md B5): the shipped SolverConfig
+default must be the unrestricted/exact solve -- the true equilibrium -- with the
+k-restriction heuristic available only as an explicit fast preview. These are
+the cheap default-guards that stop the default silently flipping back to a
+restricted (approximate) solve; the existing golden-value tests deliberately
+pin k explicitly (see test_golden_values.py) and so would NOT catch such a
+regression.
+"""
+import drafter.data.set_solve_mode as set_solve_mode
+from drafter.solver.context import SolverConfig
+
+
+def test_default_config_is_exact():
+    # Bare SolverConfig() -- what `python -m drafter` and the smoke script build
+    # -- must run the true-equilibrium solve, not the k-restricted heuristic.
+    assert SolverConfig().restrict_attackers is False
+
+
+def test_turning_on_restriction_defaults_to_preview_k():
+    # Opting into the heuristic without naming k gives the documented k=3 fast
+    # preview (B5), so a bare SolverConfig(restrict_attackers=True) IS the preview.
+    assert SolverConfig(restrict_attackers=True).restricted_attackers_count == 3
+
+
+def test_preview_mode_is_k3_restricted():
+    # The startup prompt's "fast preview" choice.
+    config = set_solve_mode.config_for_mode(preview=True)
+    assert config.restrict_attackers is True
+    assert config.restricted_attackers_count == 3
+
+
+def test_exact_mode_is_unrestricted():
+    # The startup prompt's default "exact" choice.
+    config = set_solve_mode.config_for_mode(preview=False)
+    assert config.restrict_attackers is False

--- a/scripts/smoke_draft.py
+++ b/scripts/smoke_draft.py
@@ -9,10 +9,14 @@ Exits non-zero unless at least one draft ran to completion.
 Usage (bash):        printf '\n\n\n\n\n\nn\n' | python scripts/smoke_draft.py
 Usage (PowerShell):  "","","","","","","n" | python scripts/smoke_draft.py
 
-The default Smoke opponent is a 4-player matrix that solves in about a second
-(a 4-player draft needs 6 inputs + 1 for the draft-again prompt, as above).
-Pass another folder name from drafter/resources/matches/ to smoke bigger
-matrices; an 8-player draft needs 18 inputs + 1.
+This builds a bare SolverConfig(), i.e. the shipped default, which is now the
+exact/unrestricted solve (issue #16). The default Smoke opponent is a 4-player
+matrix that solves in about a second regardless (4/6-player drafts are exact at
+any k); a 4-player draft needs 6 inputs + 1 for the draft-again prompt, as
+above. Pass another folder name from drafter/resources/matches/ to smoke bigger
+matrices; an 8-player draft needs 18 inputs + 1 and, being the exact default,
+takes ~3 min (edit the config here to SolverConfig(restrict_attackers=True) for
+the ~30 s k=3 preview).
 """
 import random
 import sys


### PR DESCRIPTION
Closes #16.

Implements the B5 decision recorded in PLAN.md (2026-07-05): the exact,
fully-unrestricted solve lands at ~3 min / <1 GB on a full 8-player team —
well under the pre-agreed ~10-min bar — so the CLI now defaults to the **true
equilibrium** rather than the k-restriction heuristic. The heuristic stays as
an explicit **fast preview**.

## Changes

- **`SolverConfig` defaults** (`drafter/solver/context.py`):
  `restrict_attackers` → `False` (exact by default; `initialise()` already maps
  this to `restriction=None` = no heuristic anywhere). `restricted_attackers_count`
  → `3`, so a bare `SolverConfig(restrict_attackers=True)` *is* the documented
  k=3 preview.
- **Startup mode prompt** (new `drafter/data/set_solve_mode.py`, wired into
  `app.run()`): after the team menu, choose **Exact** (default, ~3 min) vs
  **Fast preview** (k=3, ~30 s). The I/O is split from a pure
  `config_for_mode(preview)` so the mapping is unit-testable without a TTY.
- **Docs**: README's stale "runtime > 1 hour, change 4→3" disclaimer and
  CLAUDE.md's knob note are replaced with the exact-by-default / fast-preview
  model + the startup prompt. PLAN.md already records the decision (it's the
  direction doc, not a status tracker), so it's unchanged.
- **Tests** (new `drafter/tests/test_solve_mode.py`): default-guard tests that
  the shipped default is exact and the preview maps to k=3 restricted. The
  existing golden-value tests deliberately pin `k` explicitly, so they would
  *not* catch the default silently flipping back — hence these guards.

## Verification

- Fast suite: **92 passed, 1 deselected** (`python -m pytest`).
- CI smoke test (`scripts/smoke_draft.py` on the Smoke fixture): completes.
  Smoke is 4-player, exact at any k, so CI stays fast/green.
- Existing k-pinned golden values are **unchanged** by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)