### PR TITLE
Slice 2 (#20): in-browser solve + strategy tables

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,21 +1,34 @@
 import { useEffect, useMemo, useState } from 'react';
 import { MatrixEditor } from './components/MatrixEditor';
+import { SolveView } from './components/SolveView';
 import { blank } from './model/matrix';
 import type { EditorMatrix } from './model/matrix';
 import { loadState, saveState } from './model/storage';
 import type { AppState, Settings } from './model/storage';
+import { validateMatrix } from './model/validation';
+import { useSolve } from './worker/useSolve';
 
 type Screen = 'editor' | 'solve' | 'trainer' | 'summary';
 
 export function App() {
   const [state, setState] = useState<AppState>(() => loadState());
   const [screen, setScreen] = useState<Screen>('editor');
+  const [k, setK] = useState<number | null>(null); // null = exact (§7 default)
+  const solve = useSolve();
 
   // Persist the whole blob whenever it changes (§4.2 auto-save).
   useEffect(() => saveState(state), [state]);
 
   const matrix = useMemo(() => state.current ?? blank(8), [state.current]);
   const { settings, saves } = state;
+  const solvable = useMemo(() => validateMatrix(matrix).ok, [matrix]);
+
+  // A matrix edit invalidates any solved result (§3: reset on matrix change).
+  useEffect(() => {
+    if (solve.status !== 'idle') solve.reset();
+    // Only react to matrix identity; solve is stable enough for this guard.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [matrix]);
 
   const setMatrix = (m: EditorMatrix) => setState((s) => ({ ...s, current: m }));
   const setSettings = (next: Settings) => setState((s) => ({ ...s, settings: next }));
@@ -30,6 +43,8 @@ export function App() {
       delete rest[name];
       return { ...s, saves: rest };
     });
+
+  const goSolve = () => setScreen('solve');
 
   return (
     <div className="app">
@@ -49,7 +64,14 @@ export function App() {
           <button className={screen === 'editor' ? 'tab active' : 'tab'} onClick={() => setScreen('editor')}>
             Matrix
           </button>
-          <button className="tab" disabled title="Arrives with issue #20">Solve</button>
+          <button
+            className={screen === 'solve' ? 'tab active' : 'tab'}
+            disabled={!solvable}
+            title={solvable ? undefined : 'Complete the matrix first'}
+            onClick={goSolve}
+          >
+            Solve
+          </button>
           <button className="tab" disabled title="Arrives with issue #21">Trainer</button>
         </nav>
         <span className="spacer" />
@@ -76,6 +98,18 @@ export function App() {
             onSaveAs={saveAs}
             onLoadSave={loadSave}
             onDeleteSave={deleteSave}
+            onSolve={solvable ? goSolve : undefined}
+          />
+        )}
+        {screen === 'solve' && (
+          <SolveView
+            myTeam={matrix.myTeam}
+            enemyTeam={matrix.enemyTeam}
+            canRun={solvable}
+            solve={solve}
+            k={k}
+            onKChange={setK}
+            onRun={() => solve.solve(matrix, k)}
           />
         )}
       </main>

--- a/web/src/components/ProgressBar.tsx
+++ b/web/src/components/ProgressBar.tsx
@@ -1,0 +1,22 @@
+interface ProgressBarProps {
+  frac: number;
+  label?: string;
+}
+
+export function ProgressBar({ frac, label }: ProgressBarProps) {
+  const pct = Math.max(0, Math.min(100, frac * 100));
+  return (
+    <div className="progress-wrap">
+      <div
+        className="progress"
+        role="progressbar"
+        aria-valuenow={Math.round(pct)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+      >
+        <div className="progress-fill" style={{ width: `${pct}%` }} />
+      </div>
+      {label && <div className="progress-label">{label}</div>}
+    </div>
+  );
+}

--- a/web/src/components/SolveView.test.tsx
+++ b/web/src/components/SolveView.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import type { SolvedEvent } from '../engine/types';
+import type { SolveState } from '../worker/useSolve';
+import { SolveView } from './SolveView';
+
+const base = { solve: vi.fn(), reset: vi.fn() };
+
+const result: SolvedEvent = {
+  type: 'solved',
+  reqId: 1,
+  expected: 5,
+  root: {
+    stage: 'defender',
+    side: 'simultaneous',
+    round: 1,
+    choices: [
+      { id: 0, name: 'Alice', prob: 0.8, ev: 5.5 },
+      { id: 1, name: 'Bob', prob: 0.2, ev: 4.0 },
+    ],
+    why: {
+      rowLabels: ['Alice', 'Bob'],
+      colLabels: ['Xena', 'Yuri'],
+      payoff: [[5, 4], [3, 6]],
+      myStrategy: [0.8, 0.2],
+      enStrategy: [0.7, 0.3],
+    },
+  },
+};
+
+describe('SolveView', () => {
+  test('done: shows the 0-160 expected result and both opening mixes', () => {
+    const solve: SolveState = { ...base, status: 'done', progress: 1, phase: null, result, error: null };
+    render(<SolveView myTeam="Norway" enemyTeam="Scotland" canRun solve={solve} k={null} onKChange={() => {}} onRun={() => {}} />);
+    expect(screen.getByText('85')).toBeInTheDocument(); // 80 + 5
+    expect(screen.getByText('75')).toBeInTheDocument(); // 80 - 5
+    expect(screen.getByText(/Norway favored by 5/)).toBeInTheDocument();
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('80%')).toBeInTheDocument();
+    expect(screen.getByText('Xena')).toBeInTheDocument(); // enemy mix from colLabels
+    expect(screen.getByText('70%')).toBeInTheDocument();
+  });
+
+  test('idle: offers exact vs fast-preview and gates Run on canRun', () => {
+    const solve: SolveState = { ...base, status: 'idle', progress: 0, phase: null, result: null, error: null };
+    render(<SolveView myTeam="A" enemyTeam="B" canRun={false} solve={solve} k={null} onKChange={() => {}} onRun={() => {}} />);
+    expect(screen.getByRole('button', { name: 'Run solver' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Exact' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Fast preview/ })).toBeInTheDocument();
+  });
+
+  test('solving: shows a live progress bar', () => {
+    const solve: SolveState = { ...base, status: 'solving', progress: 0.4, phase: 'inducting', result: null, error: null };
+    render(<SolveView myTeam="A" enemyTeam="B" canRun solve={solve} k={null} onKChange={() => {}} onRun={() => {}} />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '40');
+  });
+});

--- a/web/src/components/SolveView.tsx
+++ b/web/src/components/SolveView.tsx
@@ -1,0 +1,123 @@
+import { teamResult } from '../model/scale';
+import type { SolveState } from '../worker/useSolve';
+import { ProgressBar } from './ProgressBar';
+import { StrategyTable, StrategyRow } from './StrategyTable';
+import './solve.css';
+
+interface SolveViewProps {
+  myTeam: string;
+  enemyTeam: string;
+  /** Whether the current matrix is complete/valid enough to solve. */
+  canRun: boolean;
+  solve: SolveState;
+  k: number | null;
+  onKChange: (k: number | null) => void;
+  onRun: () => void;
+  /** Provided once the trainer exists (#21). */
+  onTrain?: () => void;
+}
+
+const PHASE_LABEL = {
+  enumerating: 'Enumerating game states…',
+  inducting: 'Solving by backward induction…',
+} as const;
+
+function nameOf(name: string | [string, string]): string {
+  return typeof name === 'string' ? name : `${name[0]} + ${name[1]}`;
+}
+
+export function SolveView({ myTeam, enemyTeam, canRun, solve, k, onKChange, onRun, onTrain }: SolveViewProps) {
+  const my = myTeam || 'Your team';
+  const enemy = enemyTeam || 'Opponent';
+
+  if (solve.status === 'done' && solve.result) {
+    const { expected, root } = solve.result;
+    const score = teamResult(expected);
+    const verdict =
+      score.favored > 0 ? `${my} favored by ${score.favored}`
+      : score.favored < 0 ? `${enemy} favored by ${-score.favored}`
+      : 'Dead even';
+
+    const myRows: StrategyRow[] = root.choices
+      .map((c) => ({ name: nameOf(c.name), prob: c.prob, ev: c.ev }))
+      .sort((a, b) => b.prob - a.prob);
+
+    const why = root.why;
+    const enemyRows: StrategyRow[] = why
+      ? why.colLabels
+          .map((label, j) => ({ name: label, prob: why.enStrategy[j] }))
+          .sort((a, b) => b.prob - a.prob)
+      : [];
+
+    return (
+      <div className="solve done">
+        <div className="result-card">
+          <div className="section-head">Expected draft result</div>
+          <div className="big-score">
+            <span className="mine">{score.my}</span>
+            <span className="dash">–</span>
+            <span className="enemy">{score.enemy}</span>
+          </div>
+          <div className="verdict">{verdict}</div>
+          <div className="muted">
+            sum of 8 games · 160 points total{k !== null ? ` · fast preview (k=${k})` : ''}
+          </div>
+        </div>
+
+        <div className="mixes">
+          <StrategyTable title={`${my} — opening defender mix`} rows={myRows} accent="mine" />
+          <StrategyTable title={`${enemy} — opening defender mix`} rows={enemyRows} accent="enemy" />
+        </div>
+
+        <div className="solve-actions">
+          <div className="segmented" role="group" aria-label="Solve mode">
+            <button className={k === null ? 'on' : ''} onClick={() => onKChange(null)}>Exact</button>
+            <button className={k === 3 ? 'on' : ''} onClick={() => onKChange(3)}>Fast preview (k=3)</button>
+          </div>
+          <button onClick={onRun}>Re-run solver</button>
+          <button
+            className="primary"
+            disabled={!onTrain}
+            onClick={onTrain}
+            title={onTrain ? undefined : 'Training arrives with issue #21'}
+          >
+            Practice against the bot →
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (solve.status === 'solving') {
+    return (
+      <div className="solve solving">
+        <h2>Solving the pairing game…</h2>
+        <ProgressBar frac={solve.progress} label={solve.phase ? PHASE_LABEL[solve.phase] : 'Starting…'} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="solve idle">
+      <h2>Solve the pairing game</h2>
+      <p className="muted">
+        Computes the full draft equilibrium from the current matchup matrix: your expected team
+        result and the optimal mixed strategy for the opening defender put-up, on both sides.
+      </p>
+      <div className="solve-mode">
+        <span className="section-head">Mode</span>
+        <div className="segmented" role="group" aria-label="Solve mode">
+          <button className={k === null ? 'on' : ''} onClick={() => onKChange(null)}>Exact</button>
+          <button className={k === 3 ? 'on' : ''} onClick={() => onKChange(3)}>Fast preview (k=3)</button>
+        </div>
+      </div>
+      {solve.status === 'error' && <div className="errors">Solve failed: {solve.error}</div>}
+      <div>
+        <button className="primary run" disabled={!canRun} onClick={onRun} title={canRun ? undefined : 'Complete the matrix first'}>
+          Run solver
+        </button>
+        {!canRun && <span className="muted"> Complete the matrix to solve.</span>}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/StrategyTable.tsx
+++ b/web/src/components/StrategyTable.tsx
@@ -1,0 +1,41 @@
+export interface StrategyRow {
+  name: string;
+  prob: number;
+  ev?: number;
+}
+
+interface StrategyTableProps {
+  title: string;
+  rows: StrategyRow[];
+  accent?: 'mine' | 'enemy';
+  showEv?: boolean;
+}
+
+/** A mixed-strategy table: option name, an equilibrium-weight bar + percentage,
+ * and optionally the per-option EV. Rows are rendered in the given order
+ * (callers sort). Reused by the solve view and the trainer/Why panel. */
+export function StrategyTable({ title, rows, accent, showEv }: StrategyTableProps) {
+  return (
+    <div className={accent ? `strategy ${accent}` : 'strategy'}>
+      <div className="section-head">{title}</div>
+      <table className="strategy-table">
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.name}>
+              <td className={accent ? `sname ${accent}` : 'sname'}>{row.name}</td>
+              <td className="sbar">
+                <span style={{ width: `${Math.min(100, row.prob * 100)}%` }} />
+              </td>
+              <td className="sprob num">{(row.prob * 100).toFixed(0)}%</td>
+              {showEv && (
+                <td className="sev num">
+                  {row.ev === undefined ? '' : `${row.ev >= 0 ? '+' : ''}${row.ev.toFixed(1)}`}
+                </td>
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/web/src/components/editor.css
+++ b/web/src/components/editor.css
@@ -8,13 +8,6 @@
 }
 .editor-main { flex: 1; min-width: 0; }
 
-.section-head {
-  font-size: 0.7rem; letter-spacing: 0.08em; text-transform: uppercase;
-  color: var(--text-4); margin-bottom: 0.25rem;
-}
-
-.card { background: var(--card); border: 1px solid var(--border); border-radius: var(--radius); padding: 0.75rem; }
-.muted { color: var(--text-3); font-size: 0.85rem; }
 .privacy { color: var(--text-4); font-size: 0.78rem; line-height: 1.45; }
 
 .saved-list { display: flex; flex-direction: column; gap: 0.25rem; }
@@ -36,11 +29,6 @@
 .matchup .vs { color: var(--text-4); }
 
 .controls { display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap; margin-bottom: 0.75rem; }
-
-/* segmented toggle */
-.segmented { display: inline-flex; background: var(--bg-2); border: 1px solid var(--border-strong); border-radius: var(--radius-sm); padding: 2px; }
-.segmented button { border: 0; background: transparent; color: var(--text-3); padding: 0.35rem 0.7rem; border-radius: 6px; }
-.segmented button.on { background: var(--blue); color: #06101c; font-weight: 600; }
 
 /* grid */
 .grid-scroll { overflow-x: auto; border: 1px solid var(--border); border-radius: var(--radius); }
@@ -82,9 +70,6 @@ td.cell.invalid { outline: 2px solid var(--red); outline-offset: -2px; }
 .legend { display: flex; flex-wrap: wrap; gap: 0.4rem 1rem; margin-top: 0.6rem; font-size: 0.8rem; color: var(--text-3); }
 .legend .swatch { display: inline-flex; align-items: center; gap: 0.35rem; }
 .legend .chip { width: 0.7rem; height: 0.7rem; border-radius: 3px; }
-
-.errors { margin-top: 0.75rem; color: var(--red-soft); font-size: 0.85rem; }
-.errors ul { margin: 0.25rem 0 0 1.1rem; }
 
 .solve-bar { display: flex; align-items: center; gap: 0.75rem; margin-top: 1rem; }
 

--- a/web/src/components/solve.css
+++ b/web/src/components/solve.css
@@ -1,0 +1,44 @@
+/* Solve view (docs/design-mockup.html "Solve"). */
+
+.solve { max-width: 44rem; }
+.solve h2 { font-size: 1.3rem; margin-bottom: 0.5rem; }
+.solve .muted { margin-bottom: 1rem; }
+.solve-mode { display: flex; align-items: center; gap: 0.75rem; margin: 1.25rem 0; }
+.solve .run { margin-top: 0.25rem; }
+
+.result-card {
+  background: var(--card); border: 1px solid var(--border); border-radius: var(--radius);
+  padding: 1.25rem 1.5rem; text-align: center; margin-bottom: 1.25rem;
+}
+.big-score {
+  font-family: var(--font-mono); font-variant-numeric: tabular-nums;
+  font-size: 3rem; font-weight: 700; margin: 0.35rem 0;
+}
+.big-score .mine { color: var(--blue); }
+.big-score .enemy { color: var(--red); }
+.big-score .dash { color: var(--text-4); margin: 0 0.6rem; }
+.verdict { font-size: 1.05rem; color: var(--text); font-weight: 600; }
+
+.mixes { display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; }
+.strategy { background: var(--card); border: 1px solid var(--border); border-radius: var(--radius); padding: 0.9rem 1rem; }
+.strategy .section-head { margin-bottom: 0.6rem; }
+.strategy-table { width: 100%; border-collapse: collapse; }
+.strategy-table td { padding: 0.28rem 0.35rem; vertical-align: middle; }
+.sname { white-space: nowrap; }
+.strategy.mine .sname { color: var(--blue); }
+.strategy.enemy .sname { color: var(--red); }
+.sbar { width: 100%; }
+.sbar > span { display: block; height: 0.5rem; border-radius: 3px; background: var(--text-3); min-width: 2px; }
+.strategy.mine .sbar > span { background: var(--blue); }
+.strategy.enemy .sbar > span { background: var(--red); }
+.sprob { text-align: right; color: var(--text-2); width: 3rem; }
+.sev { text-align: right; color: var(--text-3); width: 3.2rem; }
+
+.progress-wrap { margin: 1.25rem 0; max-width: 32rem; }
+.progress { height: 0.7rem; background: var(--bg-2); border: 1px solid var(--border-strong); border-radius: 4px; overflow: hidden; }
+.progress-fill { height: 100%; background: var(--blue); transition: width 0.1s; }
+.progress-label { margin-top: 0.45rem; color: var(--text-3); font-size: 0.85rem; }
+
+.solve-actions { display: flex; gap: 0.75rem; margin-top: 1.5rem; }
+
+@media (max-width: 640px) { .mixes { grid-template-columns: 1fr; } }

--- a/web/src/model/scale.test.ts
+++ b/web/src/model/scale.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { formatCell, parseRating, scoreBand, toInputString, toScore } from './scale';
+import { formatCell, parseRating, scoreBand, teamResult, toInputString, toScore } from './scale';
 
 describe('parseRating', () => {
   test('legacy tokens map to internal deviations from an even game', () => {
@@ -56,6 +56,22 @@ describe('toInputString', () => {
     expect(toInputString(-10)).toBe('0.0'); // internal -10 = score 0 (a 20-0 loss)
     expect(toInputString(0)).toBe('10'); // internal 0 = the even game, score 10
     expect(toInputString(10)).toBe('20');
+  });
+});
+
+describe('teamResult', () => {
+  test('maps the internal margin to a 0-160 team score (80 + margin)', () => {
+    expect(teamResult(5)).toEqual({ my: 85, enemy: 75, favored: 5 });
+    expect(teamResult(0)).toEqual({ my: 80, enemy: 80, favored: 0 });
+    expect(teamResult(-3)).toEqual({ my: 77, enemy: 83, favored: -3 });
+  });
+
+  test('rounds and keeps the two scores summing to 160', () => {
+    const r = teamResult(6.189614);
+    expect(r.my).toBe(86);
+    expect(r.enemy).toBe(74);
+    expect(r.my + r.enemy).toBe(160);
+    expect(r.favored).toBe(6);
   });
 });
 

--- a/web/src/model/scale.ts
+++ b/web/src/model/scale.ts
@@ -43,6 +43,23 @@ export function toInputString(internal: number): string {
 export const formatCell = (cell: { best: number; worst: number }): string =>
   `${toScore(cell.best)} / ${toScore(cell.worst)}`;
 
+export interface TeamResult {
+  /** My team's total out of 160. */
+  my: number;
+  /** Opponent's total out of 160. */
+  enemy: number;
+  /** My margin over even (= expected internal margin, rounded). */
+  favored: number;
+}
+
+/** Convert the engine's internal team margin (sum of 8 games' deviations) to a
+ * displayed 0-160 team result: my = 80 + margin, enemy = 160 - my. The two
+ * always sum to 160 (§C, PLAN.md). */
+export function teamResult(expected: number): TeamResult {
+  const my = Math.round(80 + expected);
+  return { my, enemy: 160 - my, favored: my - 80 };
+}
+
 export type ScoreBand = 'worst' | 'bad' | 'okay' | 'good' | 'best';
 
 /** Colour band for a 0-20 score, per the editor legend: worst ≤4, bad 5-8,

--- a/web/src/theme.css
+++ b/web/src/theme.css
@@ -119,6 +119,20 @@ nav.screens { display: flex; gap: 0.25rem; flex-wrap: wrap; }
 .pill.button { cursor: pointer; }
 .pill.button:hover { border-color: var(--blue); }
 
+/* --- shared utilities (used across screens) --- */
+.section-head {
+  font-size: 0.7rem; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--text-4); margin-bottom: 0.25rem;
+}
+.card { background: var(--card); border: 1px solid var(--border); border-radius: var(--radius); padding: 0.75rem; }
+.muted { color: var(--text-3); font-size: 0.85rem; }
+.errors { margin-top: 0.75rem; color: var(--red-soft); font-size: 0.85rem; }
+.errors ul { margin: 0.25rem 0 0 1.1rem; }
+
+.segmented { display: inline-flex; background: var(--bg-2); border: 1px solid var(--border-strong); border-radius: var(--radius-sm); padding: 2px; }
+.segmented button { border: 0; background: transparent; color: var(--text-3); padding: 0.35rem 0.7rem; border-radius: 6px; }
+.segmented button.on { background: var(--blue); color: #06101c; font-weight: 600; }
+
 @media (max-width: 640px) {
   .app-header { flex-direction: column; align-items: flex-start; gap: 0.5rem; }
   .app-main { padding: 0.75rem; }

--- a/web/src/worker/useSolve.test.ts
+++ b/web/src/worker/useSolve.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import type { NodeResult, WorkerRequest, WorkerResponse } from '../engine/types';
+import type { EditorMatrix } from '../model/matrix';
+import { WorkerClient, WorkerLike } from './client';
+import { useSolve } from './useSolve';
+
+const rootNode: NodeResult = { stage: 'defender', side: 'simultaneous', round: 1, choices: [], why: null };
+
+function editor4(): EditorMatrix {
+  return {
+    n: 4,
+    myTeam: 'A',
+    enemyTeam: 'B',
+    myNames: ['a', 'b', 'c', 'd'],
+    enemyNames: ['w', 'x', 'y', 'z'],
+    cells: Array.from({ length: 4 }, () => Array.from({ length: 4 }, () => ({ b: '12', w: '9' }))),
+  };
+}
+
+class FakeWorker implements WorkerLike {
+  onmessage: ((event: MessageEvent<WorkerResponse>) => void) | null = null;
+  onerror: ((event: unknown) => void) | null = null;
+  constructor(private readonly responder: (msg: WorkerRequest, post: (m: WorkerResponse) => void) => void) {}
+  postMessage(message: WorkerRequest): void {
+    this.responder(message, (m) => this.onmessage?.({ data: m } as MessageEvent<WorkerResponse>));
+  }
+  terminate(): void {}
+}
+
+function factory(responder: (msg: WorkerRequest, post: (m: WorkerResponse) => void) => void) {
+  return () => new WorkerClient(new FakeWorker(responder));
+}
+
+describe('useSolve', () => {
+  test('forwards progress and resolves to the solved result', async () => {
+    const { result } = renderHook(() =>
+      useSolve(factory((msg, post) => {
+        post({ type: 'progress', reqId: msg.reqId, frac: 0.5, phase: 'inducting' });
+        post({ type: 'solved', reqId: msg.reqId, expected: 4.5, root: rootNode });
+      })));
+
+    act(() => result.current.solve(editor4(), null));
+    await waitFor(() => expect(result.current.status).toBe('done'));
+    expect(result.current.result?.expected).toBe(4.5);
+    expect(result.current.progress).toBe(1);
+  });
+
+  test('surfaces an engine error', async () => {
+    const { result } = renderHook(() =>
+      useSolve(factory((msg, post) =>
+        post({ type: 'error', reqId: msg.reqId, code: 'engine-error', message: 'boom' }))));
+
+    act(() => result.current.solve(editor4(), 3));
+    await waitFor(() => expect(result.current.status).toBe('error'));
+    expect(result.current.error).toMatch(/boom/);
+  });
+
+  test('reset clears the result', async () => {
+    const { result } = renderHook(() =>
+      useSolve(factory((msg, post) => post({ type: 'solved', reqId: msg.reqId, expected: 1, root: rootNode }))));
+
+    act(() => result.current.solve(editor4(), null));
+    await waitFor(() => expect(result.current.status).toBe('done'));
+    act(() => result.current.reset());
+    expect(result.current.status).toBe('idle');
+    expect(result.current.result).toBeNull();
+  });
+});

--- a/web/src/worker/useSolve.test.ts
+++ b/web/src/worker/useSolve.test.ts
@@ -58,6 +58,40 @@ describe('useSolve', () => {
     expect(result.current.error).toMatch(/boom/);
   });
 
+  test('a reset during an in-flight solve discards the stale result (generation guard)', async () => {
+    // A worker that defers its solve response but answers reset immediately —
+    // mirrors the real worker, whose synchronous solve lands before reset-ok.
+    class RacyWorker implements WorkerLike {
+      onmessage: ((event: MessageEvent<WorkerResponse>) => void) | null = null;
+      onerror: ((event: unknown) => void) | null = null;
+      pendingSolve: (() => void) | null = null;
+      postMessage(message: WorkerRequest): void {
+        if (message.type === 'solve') {
+          this.pendingSolve = () =>
+            this.onmessage?.({ data: { type: 'solved', reqId: message.reqId, expected: 9, root: rootNode } } as MessageEvent<WorkerResponse>);
+        } else if (message.type === 'reset') {
+          this.onmessage?.({ data: { type: 'reset-ok', reqId: message.reqId } } as MessageEvent<WorkerResponse>);
+        }
+      }
+      terminate(): void {}
+    }
+
+    const worker = new RacyWorker();
+    const { result } = renderHook(() => useSolve(() => new WorkerClient(worker)));
+
+    act(() => result.current.solve(editor4(), null));
+    expect(result.current.status).toBe('solving');
+    act(() => result.current.reset()); // simulate a matrix edit invalidating the solve
+    expect(result.current.status).toBe('idle');
+    // Fire the now-stale solve and flush its microtask .then handler.
+    await act(async () => {
+      worker.pendingSolve!();
+      await Promise.resolve();
+    });
+    expect(result.current.status).toBe('idle'); // must NOT flip back to 'done'
+    expect(result.current.result).toBeNull();
+  });
+
   test('reset clears the result', async () => {
     const { result } = renderHook(() =>
       useSolve(factory((msg, post) => post({ type: 'solved', reqId: msg.reqId, expected: 1, root: rootNode }))));

--- a/web/src/worker/useSolve.ts
+++ b/web/src/worker/useSolve.ts
@@ -21,6 +21,11 @@ export interface SolveState {
  * request, surfacing real progress. `makeClient` is injectable for tests. */
 export function useSolve(makeClient: () => WorkerClient = () => new WorkerClient()): SolveState {
   const clientRef = useRef<WorkerClient | null>(null);
+  // Generation token: bumped on every solve() and reset(). A worker request
+  // can't be cancelled once posted (the engine runs synchronously), so a solve
+  // that resolves after a reset/newer solve is stale and must be ignored —
+  // otherwise editing the matrix mid-solve would land an out-of-date result.
+  const genRef = useRef(0);
   const [status, setStatus] = useState<SolveStatus>('idle');
   const [progress, setProgress] = useState(0);
   const [phase, setPhase] = useState<'enumerating' | 'inducting' | null>(null);
@@ -41,6 +46,7 @@ export function useSolve(makeClient: () => WorkerClient = () => new WorkerClient
       setError((e as Error).message);
       return;
     }
+    const gen = ++genRef.current;
     setStatus('solving');
     setProgress(0);
     setPhase(null);
@@ -48,21 +54,25 @@ export function useSolve(makeClient: () => WorkerClient = () => new WorkerClient
     setResult(null);
     client()
       .solve(engineMatrix, k, (event) => {
+        if (gen !== genRef.current) return;
         setProgress(event.frac);
         setPhase(event.phase);
       })
       .then((solved) => {
+        if (gen !== genRef.current) return;
         setResult(solved);
         setProgress(1);
         setStatus('done');
       })
       .catch((e: Error) => {
+        if (gen !== genRef.current) return;
         setError(e.message);
         setStatus('error');
       });
   };
 
   const reset = () => {
+    genRef.current++;
     setStatus('idle');
     setProgress(0);
     setPhase(null);

--- a/web/src/worker/useSolve.ts
+++ b/web/src/worker/useSolve.ts
@@ -1,0 +1,75 @@
+import { useRef, useState } from 'react';
+import type { SolvedEvent } from '../engine/types';
+import type { EditorMatrix } from '../model/matrix';
+import { toEngineMatrix } from '../model/matrix';
+import { WorkerClient } from './client';
+
+export type SolveStatus = 'idle' | 'solving' | 'done' | 'error';
+
+export interface SolveState {
+  status: SolveStatus;
+  progress: number;
+  phase: 'enumerating' | 'inducting' | null;
+  result: SolvedEvent | null;
+  error: string | null;
+  /** k = null → exact; k = 3 → fast preview (§7). */
+  solve: (matrix: EditorMatrix, k: number | null) => void;
+  reset: () => void;
+}
+
+/** Owns one engine WorkerClient for the tab's lifetime and drives the §3 solve
+ * request, surfacing real progress. `makeClient` is injectable for tests. */
+export function useSolve(makeClient: () => WorkerClient = () => new WorkerClient()): SolveState {
+  const clientRef = useRef<WorkerClient | null>(null);
+  const [status, setStatus] = useState<SolveStatus>('idle');
+  const [progress, setProgress] = useState(0);
+  const [phase, setPhase] = useState<'enumerating' | 'inducting' | null>(null);
+  const [result, setResult] = useState<SolvedEvent | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const client = () => {
+    if (!clientRef.current) clientRef.current = makeClient();
+    return clientRef.current;
+  };
+
+  const solve = (matrix: EditorMatrix, k: number | null) => {
+    let engineMatrix;
+    try {
+      engineMatrix = toEngineMatrix(matrix);
+    } catch (e) {
+      setStatus('error');
+      setError((e as Error).message);
+      return;
+    }
+    setStatus('solving');
+    setProgress(0);
+    setPhase(null);
+    setError(null);
+    setResult(null);
+    client()
+      .solve(engineMatrix, k, (event) => {
+        setProgress(event.frac);
+        setPhase(event.phase);
+      })
+      .then((solved) => {
+        setResult(solved);
+        setProgress(1);
+        setStatus('done');
+      })
+      .catch((e: Error) => {
+        setError(e.message);
+        setStatus('error');
+      });
+  };
+
+  const reset = () => {
+    setStatus('idle');
+    setProgress(0);
+    setPhase(null);
+    setResult(null);
+    setError(null);
+    clientRef.current?.reset().catch(() => {});
+  };
+
+  return { status, progress, phase, result, error, solve, reset };
+}


### PR DESCRIPTION
Closes #20. Wires the solve view to the real #17 §3 worker — no engine changes.

## What's here
- **`useSolve` hook** — owns one `WorkerClient` for the tab, drives `solve()` with **real** progress events (`frac`/`phase`), exposes `{status, progress, phase, result, error, solve, reset}`. Exact (`k=null`) is the default (§7); **k=3 fast preview** is opt-in.
- **`SolveView`** (§3.5) — pre-run (heading + description + exact/preview toggle + Run), solving (live progress bar), done (the **expected team result** as `80 ± margin` → e.g. `86 – 74` + verdict + "sum of 8 games · 160 points total"), and **both opening-defender mixes** (mine from `root.choices`, enemy from `root.why.colLabels`/`enStrategy`). The mode toggle is reachable from the results screen too, so k=3 is switchable post-solve.
- **`StrategyTable` + `ProgressBar`** (reused by #21); `scale.teamResult` (TDD).
- **App**: enables the Solve tab, invalidates a solved result on any matrix edit (§3 reset-on-change).
- Moves shared CSS utilities to `theme.css`.

## Verification
- `typecheck` clean; `npm test` **64 passed / 3 skipped** (full `CONFORMANCE_SLOW=1` run passes — engine values unchanged, pinned to 1e-9).
- **In-browser, real worker** (Scotland sample): exact → **86 – 74, "favored by 6"** (golden `expected=6.137780`); k=3 preview → **86 – 74** labelled "fast preview (k=3)" (golden `5.875946`); each completes in ~seconds. Opening mixes are true equilibria (mine: Mariusz 86% / Petter 14%; enemy: Drukhari 66% / Sisters 34%) — correctly different from the mockup's throwaway stub (§5). No console errors.

Note: preview-tool screenshots were timing out this session (a tooling quirk, not an app issue — the page responds to all DOM queries with zero console errors), so verification evidence is DOM-level rather than an image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)