### PR TITLE
Slice 3 (#21): full train-against-the-bot

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -133,6 +133,7 @@ export function App() {
           <SolveView
             myTeam={matrix.myTeam}
             enemyTeam={matrix.enemyTeam}
+            n={matrix.n}
             canRun={solvable}
             solve={solve}
             k={k}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,19 +1,26 @@
 import { useEffect, useMemo, useState } from 'react';
+import { DraftTrainer } from './components/DraftTrainer';
 import { MatrixEditor } from './components/MatrixEditor';
 import { SolveView } from './components/SolveView';
-import { blank } from './model/matrix';
+import type { BotStyle } from './draft/sampling';
+import { blank, toEngineMatrix } from './model/matrix';
 import type { EditorMatrix } from './model/matrix';
 import { loadState, saveState } from './model/storage';
 import type { AppState, Settings } from './model/storage';
 import { validateMatrix } from './model/validation';
 import { useSolve } from './worker/useSolve';
 
-type Screen = 'editor' | 'solve' | 'trainer' | 'summary';
+type Screen = 'editor' | 'solve' | 'trainer';
+
+// The worker defaults the neutral-game weight to 0.5 (§4/§7); the trainer's
+// pairing values must use the same to match the engine's totals.
+const NEUTRAL_WEIGHT = 0.5;
 
 export function App() {
   const [state, setState] = useState<AppState>(() => loadState());
   const [screen, setScreen] = useState<Screen>('editor');
   const [k, setK] = useState<number | null>(null); // null = exact (§7 default)
+  const [botStyle, setBotStyle] = useState<BotStyle>('equilibrium');
   const solve = useSolve();
 
   // Persist the whole blob whenever it changes (§4.2 auto-save).
@@ -22,6 +29,13 @@ export function App() {
   const matrix = useMemo(() => state.current ?? blank(8), [state.current]);
   const { settings, saves } = state;
   const solvable = useMemo(() => validateMatrix(matrix).ok, [matrix]);
+  const engineMatrix = useMemo(() => {
+    try {
+      return solvable ? toEngineMatrix(matrix) : null;
+    } catch {
+      return null;
+    }
+  }, [matrix, solvable]);
 
   // A matrix edit invalidates any solved result (§3: reset on matrix change).
   useEffect(() => {
@@ -45,6 +59,13 @@ export function App() {
     });
 
   const goSolve = () => setScreen('solve');
+  const startTraining = () => {
+    if (!solvable) return;
+    // The trainer runs on the exact equilibrium; re-solve if the current
+    // result is a k-preview (or missing).
+    if (!(solve.status === 'done' && solve.solvedK === null)) solve.solve(matrix, null);
+    setScreen('trainer');
+  };
 
   return (
     <div className="app">
@@ -72,7 +93,14 @@ export function App() {
           >
             Solve
           </button>
-          <button className="tab" disabled title="Arrives with issue #21">Trainer</button>
+          <button
+            className={screen === 'trainer' ? 'tab active' : 'tab'}
+            disabled={!solvable}
+            title={solvable ? undefined : 'Complete the matrix first'}
+            onClick={startTraining}
+          >
+            Trainer
+          </button>
         </nav>
         <span className="spacer" />
         <span className="pill" title="Everything runs in your browser; nothing is uploaded.">
@@ -110,6 +138,19 @@ export function App() {
             k={k}
             onKChange={setK}
             onRun={() => solve.solve(matrix, k)}
+            onTrain={solvable ? startTraining : undefined}
+          />
+        )}
+        {screen === 'trainer' && engineMatrix && (
+          <DraftTrainer
+            matrix={engineMatrix}
+            myTeam={matrix.myTeam}
+            enemyTeam={matrix.enemyTeam}
+            neutralWeight={NEUTRAL_WEIGHT}
+            solve={solve}
+            botStyle={botStyle}
+            onBotStyleChange={setBotStyle}
+            onEditMatrix={() => setScreen('editor')}
           />
         )}
       </main>

--- a/web/src/components/DraftSummary.tsx
+++ b/web/src/components/DraftSummary.tsx
@@ -28,8 +28,8 @@ function joinName(name: string | [string, string]): string {
 
 export function DraftSummary({ myTeam, enemyTeam, myNames, enemyNames, expected, model, onReplay, onEditMatrix }: DraftSummaryProps) {
   const achieved = achievedTotal(model);
-  const score = teamResult(achieved);
-  const plan = teamResult(expected);
+  const score = teamResult(achieved, model.n);
+  const plan = teamResult(expected, model.n);
   const d = decompose(model.decisions, expected, achieved);
   const v = verdict(score.my, score.enemy, d);
 

--- a/web/src/components/DraftSummary.tsx
+++ b/web/src/components/DraftSummary.tsx
@@ -1,0 +1,102 @@
+import { achievedTotal } from '../draft/draftState';
+import type { DraftModel, FixedGame } from '../draft/draftState';
+import { decompose, verdict } from '../draft/summary';
+import { teamResult, toScore } from '../model/scale';
+import './trainer.css';
+
+interface DraftSummaryProps {
+  myTeam: string;
+  enemyTeam: string;
+  myNames: string[];
+  enemyNames: string[];
+  expected: number;
+  model: DraftModel;
+  onReplay: () => void;
+  onEditMatrix: () => void;
+}
+
+const KIND_LABEL: Record<FixedGame['kind'], string> = {
+  'my-defends': 'you defended',
+  'enemy-defends': 'they defended',
+  refused: 'refused pair',
+  last: 'last players',
+};
+
+function joinName(name: string | [string, string]): string {
+  return typeof name === 'string' ? name : `${name[0]} + ${name[1]}`;
+}
+
+export function DraftSummary({ myTeam, enemyTeam, myNames, enemyNames, expected, model, onReplay, onEditMatrix }: DraftSummaryProps) {
+  const achieved = achievedTotal(model);
+  const score = teamResult(achieved);
+  const plan = teamResult(expected);
+  const d = decompose(model.decisions, expected, achieved);
+  const v = verdict(score.my, score.enemy, d);
+
+  return (
+    <div className="summary">
+      <div className="result-card">
+        <div className="result-label">{v.result}</div>
+        <div className="big-score">
+          <span className="mine">{score.my}</span>
+          <span className="dash">–</span>
+          <span className="enemy">{score.enemy}</span>
+        </div>
+        <div className="summary-line">{v.summary}</div>
+        <div className="muted">planned {plan.my}–{plan.enemy} · you drafted {score.my >= plan.my ? '+' : ''}{score.my - plan.my} vs the solver's expectation</div>
+      </div>
+
+      <div className="decomp">
+        <div className="metric">
+          <div className="mval" style={{ color: 'var(--red-soft)' }}>−{d.totalRegret.toFixed(1)}</div>
+          <div className="mlabel">your picks (regret)</div>
+        </div>
+        <div className="metric">
+          <div className="mval" style={{ color: d.variance >= 0 ? 'var(--green)' : 'var(--amber)' }}>
+            {d.variance >= 0 ? '+' : ''}{d.variance.toFixed(1)}
+          </div>
+          <div className="mlabel">reveal variance (luck)</div>
+        </div>
+      </div>
+
+      {d.leaks.length > 0 && (
+        <div>
+          <div className="section-head">Where you left points (worst first)</div>
+          <div className="leaks-list">
+            {d.leaks.map((leak, i) => (
+              <div className="leak" key={i}>
+                R{leak.round} {leak.stage} — sent {joinName(leak.chosenName)} · best {joinName(leak.bestName)}{' '}
+                <span className="lcost">−{leak.regret.toFixed(1)}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="locked">
+        <div className="section-head">Final pairings</div>
+        <div className="locked-list">
+          {model.fixed.map((game, i) => {
+            const my = toScore(game.value);
+            return (
+              <div className="pairing" key={i}>
+                <span className="pmine">{myNames[game.my]}</span>
+                <span className="pscore">{my.toFixed(1)}–{(20 - my).toFixed(1)}</span>
+                <span className="penemy">{enemyNames[game.enemy]}</span>
+                <span className="pkind">{KIND_LABEL[game.kind]}</span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="summary-actions">
+        <button className="primary" onClick={onReplay}>Draft again</button>
+        <button onClick={onEditMatrix}>Back to matrix</button>
+      </div>
+      <p className="muted" style={{ marginTop: '0.75rem' }}>
+        {myTeam || 'You'} vs {enemyTeam || 'the opponent'} · scored against the solver's pre-draft expectation.
+      </p>
+    </div>
+  );
+}

--- a/web/src/components/DraftTrainer.test.tsx
+++ b/web/src/components/DraftTrainer.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test, vi } from 'vitest';
+import { fixtureMatrix, smoke } from '../conformance/fixtures';
+import { DraftEngine } from '../engine/engine';
+import type { Move } from '../engine/types';
+import type { SolveState } from '../worker/useSolve';
+import { DraftTrainer } from './DraftTrainer';
+
+/** A SolveState backed by a real exact engine — node() walks the real tree, so
+ * the trainer plays against genuine equilibrium strategies (no worker). */
+function engineSolveState(): SolveState {
+  const engine = new DraftEngine(fixtureMatrix(smoke), null, smoke.neutralWeight);
+  const expected = engine.solve();
+  return {
+    status: 'done',
+    progress: 1,
+    phase: null,
+    result: { type: 'solved', reqId: 1, expected, root: engine.nodeResult([]) },
+    error: null,
+    solvedK: null,
+    solve: vi.fn(),
+    reset: vi.fn(),
+    node: (path: Move[]) => Promise.resolve(engine.nodeResult(path)),
+  };
+}
+
+describe('DraftTrainer (Smoke 4×4, real engine)', () => {
+  test('plays a full draft from intro to the summary', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <DraftTrainer
+        matrix={fixtureMatrix(smoke)}
+        myTeam="Us"
+        enemyTeam="Them"
+        neutralWeight={smoke.neutralWeight}
+        solve={engineSolveState()}
+        botStyle="greedy"
+        onBotStyleChange={() => {}}
+        onEditMatrix={() => {}}
+      />,
+    );
+
+    await user.click(await screen.findByRole('button', { name: /Start practice draft/ }));
+
+    // A 4×4 draft is one round: defender → attackers → refusal.
+    for (let step = 0; step < 3; step++) {
+      const choice = await waitFor(() => {
+        const first = container.querySelector('.choice');
+        if (!first) throw new Error('choices not rendered yet');
+        return first as HTMLElement;
+      });
+      await user.click(choice);
+      await user.click(screen.getByRole('button', { name: /^Lock/ }));
+    }
+
+    // Reaching 'done' renders the summary.
+    expect(await screen.findByRole('button', { name: /Draft again/ })).toBeInTheDocument();
+    expect(screen.getByText(/Final pairings/i)).toBeInTheDocument();
+  });
+
+  test('undo steps back a decision', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <DraftTrainer
+        matrix={fixtureMatrix(smoke)}
+        myTeam="Us"
+        enemyTeam="Them"
+        neutralWeight={smoke.neutralWeight}
+        solve={engineSolveState()}
+        botStyle="greedy"
+        onBotStyleChange={() => {}}
+        onEditMatrix={() => {}}
+      />,
+    );
+    await user.click(await screen.findByRole('button', { name: /Start practice draft/ }));
+
+    // Lock the defender, advance to attackers, then undo back to defender.
+    await user.click(await waitFor(() => container.querySelector('.choice') as HTMLElement));
+    await user.click(screen.getByRole('button', { name: 'Lock defender' }));
+    await screen.findByRole('button', { name: 'Lock attackers' });
+    await user.click(screen.getByRole('button', { name: /Undo/ }));
+    expect(await screen.findByRole('button', { name: 'Lock defender' })).toBeInTheDocument();
+  });
+});

--- a/web/src/components/DraftTrainer.tsx
+++ b/web/src/components/DraftTrainer.tsx
@@ -1,0 +1,212 @@
+import { useRef, useState } from 'react';
+import type { Matrix, NodeResult } from '../engine/types';
+import type { BotStyle } from '../draft/sampling';
+import { sampleIndex } from '../draft/sampling';
+import type { DraftModel } from '../draft/draftState';
+import { applyStep, initDraft } from '../draft/draftState';
+import { toScore } from '../model/scale';
+import type { SolveState } from '../worker/useSolve';
+import { DraftSummary } from './DraftSummary';
+import { ProgressBar } from './ProgressBar';
+import { WhyPanel } from './WhyPanel';
+import './trainer.css';
+
+interface DraftTrainerProps {
+  matrix: Matrix;
+  myTeam: string;
+  enemyTeam: string;
+  neutralWeight: number;
+  solve: SolveState;
+  botStyle: BotStyle;
+  onBotStyleChange: (style: BotStyle) => void;
+  onEditMatrix: () => void;
+}
+
+const STAGE_COPY = {
+  defender: { title: 'Select your defender', sub: 'Both captains put up a defender at the same time.' },
+  attackers: { title: 'Send two attackers', sub: 'You send two — the enemy chooses which one your defender faces.' },
+  refusal: { title: 'Refuse an attacker', sub: 'Refuse one of their two attackers; your defender plays the one you keep.' },
+} as const;
+
+function joinName(name: string | [string, string]): string {
+  return typeof name === 'string' ? name : `${name[0]} + ${name[1]}`;
+}
+
+export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, botStyle, onBotStyleChange, onEditMatrix }: DraftTrainerProps) {
+  const { myNames, enemyNames } = matrix;
+  const [model, setModel] = useState<DraftModel | null>(null);
+  const [history, setHistory] = useState<DraftModel[]>([]);
+  const [node, setNode] = useState<NodeResult | null>(null);
+  const [selected, setSelected] = useState<number | null>(null);
+  const [reveal, setReveal] = useState<{ mine: string; enemy: string } | null>(null);
+  const [showWhy, setShowWhy] = useState(false);
+  const [hints, setHints] = useState(true);
+  const rng = useRef<() => number>(Math.random);
+
+  const ready = solve.status === 'done' && solve.solvedK === null;
+  const expected = solve.result?.expected ?? 0;
+  const finalRound = (matrix.n - 4) / 2 + 1;
+  const enemy = enemyTeam || 'The bot';
+
+  const start = () => {
+    if (!ready) return;
+    setModel(initDraft(matrix, neutralWeight));
+    setHistory([]);
+    setSelected(null);
+    setReveal(null);
+    setShowWhy(false);
+    solve.node([]).then(setNode).catch(() => {});
+  };
+
+  // --- intro ---
+  if (model === null) {
+    return (
+      <div className="trainer">
+        <h2>Practice draft vs the bot</h2>
+        <ul className="muted" style={{ margin: '0.5rem 0 1rem 1.1rem', lineHeight: 1.6 }}>
+          {finalRound > 1 && (
+            <li>Rounds 1–{finalRound - 1} — put up a defender, send two attackers, then refuse one of theirs; two games lock each round.</li>
+          )}
+          <li>Round {finalRound} — four players: the two refused attackers face each other and the last players pair automatically, resolving the remaining games.</li>
+          <li>Both captains pick secretly at every step. The bot's choice is revealed only after you lock yours.</li>
+          <li>At the end you're scored against the solver's pre-draft expectation.</li>
+        </ul>
+        {solve.status === 'solving' && <ProgressBar frac={solve.progress} label="Solving exactly for training…" />}
+        <button className="primary" disabled={!ready} onClick={start}>Start practice draft</button>
+        {!ready && solve.status !== 'solving' && <span className="muted"> Solve the matrix first.</span>}
+      </div>
+    );
+  }
+
+  if (model.done) {
+    return (
+      <DraftSummary
+        myTeam={myTeam}
+        enemyTeam={enemyTeam}
+        myNames={myNames}
+        enemyNames={enemyNames}
+        expected={expected}
+        model={model}
+        onReplay={start}
+        onEditMatrix={onEditMatrix}
+      />
+    );
+  }
+
+  if (!node) return <p className="placeholder">Loading the next decision…</p>;
+
+  const stage = node.stage as 'defender' | 'attackers' | 'refusal';
+  const copy = STAGE_COPY[stage];
+
+  const lock = () => {
+    if (selected === null || !node.why) return;
+    const colIndex = sampleIndex(node.why.enStrategy, botStyle, rng.current);
+    const myLabel = joinName(node.choices[selected].name);
+    const enemyLabel = node.why.colLabels[colIndex];
+    const next = applyStep(model, node, selected, colIndex);
+    setHistory([...history, model]);
+    setModel(next);
+    setSelected(null);
+    setShowWhy(false);
+    setReveal(
+      stage === 'refusal'
+        ? { mine: `refuse ${myLabel}`, enemy: `refuse ${enemyLabel}` }
+        : { mine: myLabel, enemy: enemyLabel },
+    );
+    if (next.done) setNode(null);
+    else solve.node(next.path).then(setNode).catch(() => {});
+  };
+
+  const undo = () => {
+    if (history.length === 0) return;
+    const prev = history[history.length - 1];
+    setHistory(history.slice(0, -1));
+    setModel(prev);
+    setSelected(null);
+    setReveal(null);
+    setShowWhy(false);
+    solve.node(prev.path).then(setNode).catch(() => {});
+  };
+
+  return (
+    <div className="trainer">
+      <div className="trainer-head">
+        <h2>{copy.title}</h2>
+        <span className="round-badge">Round {node.round} / {finalRound}</span>
+      </div>
+      <p className="trainer-sub">{copy.sub}</p>
+
+      <div className="trainer-controls">
+        <label className="style-select">
+          Bot
+          <select value={botStyle} onChange={(e) => onBotStyleChange(e.target.value as BotStyle)}>
+            <option value="equilibrium">Equilibrium</option>
+            <option value="greedy">Greedy</option>
+            <option value="wildcard">Wildcard</option>
+          </select>
+        </label>
+        <button className={hints ? 'tab active' : 'tab'} onClick={() => setHints((h) => !h)}>
+          Hints: {hints ? 'on' : 'off'}
+        </button>
+        <button className={showWhy ? 'tab active' : 'tab'} onClick={() => setShowWhy((w) => !w)} disabled={!node.why}>
+          Why
+        </button>
+        <span className="spacer" />
+        <button onClick={undo} disabled={history.length === 0}>↩ Undo</button>
+      </div>
+
+      {reveal && (
+        <div className="reveal">
+          <span>You: <span className="r-mine">{reveal.mine}</span></span>
+          <span>{enemy}: <span className="r-enemy">{reveal.enemy}</span></span>
+        </div>
+      )}
+
+      <div className="choices">
+        {node.choices.map((choice, i) => (
+          <button
+            key={i}
+            className={selected === i ? 'choice selected' : 'choice'}
+            onClick={() => setSelected(i)}
+          >
+            <span className="cname">
+              {stage === 'refusal' ? `Refuse ${joinName(choice.name)}` : joinName(choice.name)}
+            </span>
+            {hints && (
+              <>
+                <span className="cbar"><span style={{ width: `${Math.min(100, choice.prob * 100)}%` }} /></span>
+                <span className="cprob">{(choice.prob * 100).toFixed(0)}%</span>
+                <span className="cev">{choice.ev >= 0 ? '+' : ''}{choice.ev.toFixed(1)}</span>
+              </>
+            )}
+          </button>
+        ))}
+      </div>
+
+      <div className="lock-bar">
+        <button className="primary" disabled={selected === null} onClick={lock}>Lock {stage}</button>
+        <span className="muted">{enemy} picks simultaneously — revealed after you lock.</span>
+      </div>
+
+      {showWhy && <WhyPanel node={node} />}
+
+      {model.fixed.length > 0 && (
+        <div className="locked">
+          <div className="section-head">Locked pairings ({model.fixed.length})</div>
+          <div className="locked-list">
+            {model.fixed.map((game, i) => {
+              const my = toScore(game.value);
+              return (
+                <div className="pairing" key={i}>
+                  <span className="pmine">{myNames[game.my]}</span>
+                  <span className="pscore">{my.toFixed(1)}–{(20 - my).toFixed(1)}</span>
+                  <span className="penemy">{enemyNames[game.enemy]}</span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/SolveView.test.tsx
+++ b/web/src/components/SolveView.test.tsx
@@ -33,7 +33,7 @@ const result: SolvedEvent = {
 describe('SolveView', () => {
   test('done: shows the 0-160 expected result and both opening mixes', () => {
     const solve: SolveState = { ...base, status: 'done', progress: 1, phase: null, result, error: null };
-    render(<SolveView myTeam="Norway" enemyTeam="Scotland" canRun solve={solve} k={null} onKChange={() => {}} onRun={() => {}} />);
+    render(<SolveView myTeam="Norway" enemyTeam="Scotland" n={8} canRun solve={solve} k={null} onKChange={() => {}} onRun={() => {}} />);
     expect(screen.getByText('85')).toBeInTheDocument(); // 80 + 5
     expect(screen.getByText('75')).toBeInTheDocument(); // 80 - 5
     expect(screen.getByText(/Norway favored by 5/)).toBeInTheDocument();
@@ -45,7 +45,7 @@ describe('SolveView', () => {
 
   test('idle: offers exact vs fast-preview and gates Run on canRun', () => {
     const solve: SolveState = { ...base, status: 'idle', progress: 0, phase: null, result: null, error: null };
-    render(<SolveView myTeam="A" enemyTeam="B" canRun={false} solve={solve} k={null} onKChange={() => {}} onRun={() => {}} />);
+    render(<SolveView myTeam="A" enemyTeam="B" n={8} canRun={false} solve={solve} k={null} onKChange={() => {}} onRun={() => {}} />);
     expect(screen.getByRole('button', { name: 'Run solver' })).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Exact' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Fast preview/ })).toBeInTheDocument();
@@ -53,7 +53,7 @@ describe('SolveView', () => {
 
   test('solving: shows a live progress bar', () => {
     const solve: SolveState = { ...base, status: 'solving', progress: 0.4, phase: 'inducting', result: null, error: null };
-    render(<SolveView myTeam="A" enemyTeam="B" canRun solve={solve} k={null} onKChange={() => {}} onRun={() => {}} />);
+    render(<SolveView myTeam="A" enemyTeam="B" n={8} canRun solve={solve} k={null} onKChange={() => {}} onRun={() => {}} />);
     expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '40');
   });
 });

--- a/web/src/components/SolveView.test.tsx
+++ b/web/src/components/SolveView.test.tsx
@@ -6,7 +6,7 @@ import type { SolvedEvent } from '../engine/types';
 import type { SolveState } from '../worker/useSolve';
 import { SolveView } from './SolveView';
 
-const base = { solve: vi.fn(), reset: vi.fn() };
+const base = { solve: vi.fn(), reset: vi.fn(), node: vi.fn(), solvedK: null };
 
 const result: SolvedEvent = {
   type: 'solved',

--- a/web/src/components/SolveView.tsx
+++ b/web/src/components/SolveView.tsx
@@ -7,6 +7,8 @@ import './solve.css';
 interface SolveViewProps {
   myTeam: string;
   enemyTeam: string;
+  /** Team size, for the displayed team-result baseline (20n total). */
+  n: number;
   /** Whether the current matrix is complete/valid enough to solve. */
   canRun: boolean;
   solve: SolveState;
@@ -26,13 +28,13 @@ function nameOf(name: string | [string, string]): string {
   return typeof name === 'string' ? name : `${name[0]} + ${name[1]}`;
 }
 
-export function SolveView({ myTeam, enemyTeam, canRun, solve, k, onKChange, onRun, onTrain }: SolveViewProps) {
+export function SolveView({ myTeam, enemyTeam, n, canRun, solve, k, onKChange, onRun, onTrain }: SolveViewProps) {
   const my = myTeam || 'Your team';
   const enemy = enemyTeam || 'Opponent';
 
   if (solve.status === 'done' && solve.result) {
     const { expected, root } = solve.result;
-    const score = teamResult(expected);
+    const score = teamResult(expected, n);
     const verdict =
       score.favored > 0 ? `${my} favored by ${score.favored}`
       : score.favored < 0 ? `${enemy} favored by ${-score.favored}`
@@ -60,7 +62,7 @@ export function SolveView({ myTeam, enemyTeam, canRun, solve, k, onKChange, onRu
           </div>
           <div className="verdict">{verdict}</div>
           <div className="muted">
-            sum of 8 games · 160 points total{k !== null ? ` · fast preview (k=${k})` : ''}
+            sum of {n} games · {20 * n} points total{k !== null ? ` · fast preview (k=${k})` : ''}
           </div>
         </div>
 

--- a/web/src/components/WhyPanel.tsx
+++ b/web/src/components/WhyPanel.tsx
@@ -1,0 +1,50 @@
+import type { NodeResult } from '../engine/types';
+
+/** The Why panel (§3.3): the payoff matrix at the current node (child game
+ * values, internal team-margin scale) with both equilibrium mixes on the
+ * margins and the support cells highlighted. */
+export function WhyPanel({ node }: { node: NodeResult }) {
+  const why = node.why;
+  if (!why) return null;
+  const unit = node.stage === 'defender' ? 'defender' : node.stage === 'attackers' ? 'attacker pair' : 'refusal';
+
+  return (
+    <div className="why">
+      <div className="section-head">Payoff — team margin per {unit} choice (rows = you, cols = them)</div>
+      <div className="why-scroll">
+        <table className="why-table">
+          <thead>
+            <tr>
+              <th className="wcorner" />
+              {why.colLabels.map((label, j) => (
+                <th key={j}>
+                  <div className="wlabel enemy">{label}</div>
+                  <div className="wprob">{(why.enStrategy[j] * 100).toFixed(0)}%</div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {why.rowLabels.map((label, i) => (
+              <tr key={i}>
+                <th className="wrow">
+                  <span className="wlabel mine">{label}</span>
+                  <span className="wprob">{(why.myStrategy[i] * 100).toFixed(0)}%</span>
+                </th>
+                {why.colLabels.map((_, j) => {
+                  const v = why.payoff[i][j];
+                  const support = why.myStrategy[i] > 1e-6 && why.enStrategy[j] > 1e-6;
+                  return (
+                    <td key={j} className={support ? 'wcell support num' : 'wcell num'}>
+                      {v >= 0 ? '+' : ''}{v.toFixed(1)}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/trainer.css
+++ b/web/src/components/trainer.css
@@ -1,0 +1,74 @@
+/* Draft trainer + summary (docs/design-mockup.html "Trainer"). */
+
+.trainer { max-width: 52rem; }
+.trainer-head { display: flex; align-items: baseline; gap: 0.75rem; flex-wrap: wrap; margin-bottom: 0.25rem; }
+.trainer-head h2 { font-size: 1.25rem; }
+.round-badge { color: var(--text-3); font-family: var(--font-mono); }
+.trainer-sub { color: var(--text-3); margin-bottom: 1rem; }
+
+.trainer-controls { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; margin-bottom: 1rem; }
+.trainer-controls .spacer { flex: 1; }
+.style-select { display: flex; align-items: center; gap: 0.4rem; color: var(--text-3); font-size: 0.85rem; }
+
+.reveal {
+  display: flex; gap: 1rem; flex-wrap: wrap; padding: 0.6rem 0.9rem; margin-bottom: 1rem;
+  background: var(--card); border: 1px solid var(--border); border-radius: var(--radius-sm);
+  animation: wtcFlip 0.45s ease-out;
+}
+.reveal .r-mine { color: var(--blue); font-weight: 600; }
+.reveal .r-enemy { color: var(--red); font-weight: 600; }
+@keyframes wtcFlip { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: none; } }
+
+.choices { display: flex; flex-direction: column; gap: 0.4rem; }
+.choice {
+  display: flex; align-items: center; gap: 0.75rem; width: 100%; text-align: left;
+  padding: 0.6rem 0.9rem; background: var(--card); border: 1px solid var(--border-strong); border-radius: var(--radius-sm);
+}
+.choice:hover:not(:disabled) { border-color: var(--blue); }
+.choice.selected { border-color: var(--blue); background: var(--card-2); }
+.choice .cname { flex: 1; font-weight: 600; }
+.choice .cprob { color: var(--text-2); font-family: var(--font-mono); width: 3.5rem; text-align: right; }
+.choice .cbar { width: 6rem; height: 0.4rem; background: var(--bg-2); border-radius: 3px; overflow: hidden; }
+.choice .cbar > span { display: block; height: 100%; background: var(--blue); }
+.choice .cev { color: var(--text-3); font-family: var(--font-mono); width: 4rem; text-align: right; }
+
+.lock-bar { display: flex; align-items: center; gap: 0.75rem; margin-top: 1rem; }
+
+.why { margin-top: 1.25rem; }
+.why-scroll { overflow-x: auto; border: 1px solid var(--border); border-radius: var(--radius); }
+.why-table { border-collapse: collapse; width: 100%; font-size: 0.85rem; }
+.why-table th, .why-table td { border: 1px solid var(--border); padding: 0.35rem 0.5rem; text-align: center; }
+.why-table .wcorner { background: var(--bg-2); }
+.why-table .wrow { text-align: left; white-space: nowrap; background: var(--bg-2); }
+.wlabel.mine { color: var(--blue); }
+.wlabel.enemy { color: var(--red); }
+.wprob { color: var(--text-4); font-family: var(--font-mono); font-size: 0.78rem; }
+.wcell { color: var(--text-3); }
+.wcell.support { color: var(--text); background: #4e9af114; font-weight: 600; }
+
+.locked { margin-top: 1.5rem; }
+.locked-list { display: flex; flex-direction: column; gap: 0.3rem; }
+.pairing {
+  display: flex; align-items: center; gap: 0.6rem; padding: 0.4rem 0.7rem;
+  background: var(--card); border: 1px solid var(--border); border-radius: var(--radius-sm); font-size: 0.9rem;
+}
+.pairing .pmine { color: var(--blue); font-weight: 600; }
+.pairing .penemy { color: var(--red); font-weight: 600; }
+.pairing .pkind { color: var(--text-4); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.04em; margin-left: auto; }
+.pairing .pscore { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
+
+/* summary */
+.summary { max-width: 48rem; }
+.summary .result-card { margin-bottom: 1rem; }
+.result-label { font-size: 0.8rem; letter-spacing: 0.1em; color: var(--text-3); text-transform: uppercase; }
+.summary-line { font-size: 1.05rem; color: var(--text-1); margin: 0.5rem 0 0.25rem; }
+.decomp { display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; margin: 1rem 0; }
+.decomp .metric { background: var(--card); border: 1px solid var(--border); border-radius: var(--radius); padding: 0.8rem 1rem; text-align: center; }
+.decomp .metric .mval { font-family: var(--font-mono); font-size: 1.6rem; font-weight: 700; }
+.decomp .metric .mlabel { color: var(--text-3); font-size: 0.82rem; }
+.leaks-list { display: flex; flex-direction: column; gap: 0.3rem; }
+.leak { padding: 0.4rem 0.7rem; background: var(--card); border: 1px solid var(--border); border-radius: var(--radius-sm); font-size: 0.88rem; }
+.leak .lcost { color: var(--red-soft); font-family: var(--font-mono); }
+.summary-actions { display: flex; gap: 0.75rem; margin-top: 1.25rem; }
+
+@media (max-width: 640px) { .decomp { grid-template-columns: 1fr; } }

--- a/web/src/draft/draftState.test.ts
+++ b/web/src/draft/draftState.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'vitest';
+import { fixtureMatrix, smoke } from '../conformance/fixtures';
+import { DraftEngine } from '../engine/engine';
+import { achievedTotal, applyStep, initDraft } from './draftState';
+
+function argmax(values: number[]): number {
+  let best = 0;
+  for (let i = 1; i < values.length; i++) if (values[i] > values[best]) best = i;
+  return best;
+}
+
+describe('draftState (Smoke 4×4, exact engine)', () => {
+  const matrix = fixtureMatrix(smoke);
+  const engine = new DraftEngine(matrix, null, smoke.neutralWeight);
+  engine.solve();
+
+  function walk(pick: (node: ReturnType<typeof engine.nodeResult>) => number) {
+    let model = initDraft(matrix, smoke.neutralWeight);
+    while (!model.done) {
+      const node = engine.nodeResult(model.path);
+      model = applyStep(model, node, pick(node), argmax(node.why!.enStrategy));
+    }
+    return model;
+  }
+
+  test('a full 4×4 draft fixes exactly 4 games of the right kinds', () => {
+    const model = walk((node) => argmax(node.choices.map((c) => c.prob)));
+    expect(model.done).toBe(true);
+    expect(model.fixed).toHaveLength(4);
+    expect(model.fixed.map((g) => g.kind).sort()).toEqual(['enemy-defends', 'last', 'my-defends', 'refused']);
+    // every player index appears once per side
+    expect(model.fixed.map((g) => g.my).sort()).toEqual([0, 1, 2, 3]);
+    expect(model.fixed.map((g) => g.enemy).sort()).toEqual([0, 1, 2, 3]);
+  });
+
+  test('each fixed game carries the correct value-model value', () => {
+    const model = walk((node) => argmax(node.choices.map((c) => c.prob)));
+    for (const g of model.fixed) {
+      const cell = matrix.cells[g.my][g.enemy];
+      const expectedValue =
+        g.kind === 'my-defends' ? cell.best
+        : g.kind === 'enemy-defends' ? cell.worst
+        : cell.worst + smoke.neutralWeight * (cell.best - cell.worst);
+      expect(g.value).toBeCloseTo(expectedValue, 9);
+    }
+  });
+
+  test('following the equilibrium (argmax) leaves zero regret', () => {
+    const model = walk((node) => argmax(node.choices.map((c) => c.prob)));
+    for (const d of model.decisions) expect(d.regret).toBeGreaterThanOrEqual(-1e-9);
+    const totalRegret = model.decisions.reduce((sum, d) => sum + d.regret, 0);
+    expect(totalRegret).toBeCloseTo(0, 9);
+    expect(Number.isFinite(achievedTotal(model))).toBe(true);
+  });
+
+  test('deliberately picking the worst-EV option incurs positive regret', () => {
+    const model = walk((node) => argmax(node.choices.map((c) => -c.ev))); // min-ev pick
+    const worstDecision = model.decisions.find((d) => d.regret > 1e-9);
+    expect(worstDecision).toBeDefined();
+  });
+});

--- a/web/src/draft/draftState.ts
+++ b/web/src/draft/draftState.ts
@@ -1,0 +1,201 @@
+import type { Matrix, Move, NodeResult } from '../engine/types';
+
+/** One of the 8 games fixed by the draft, with its value-model value (internal
+ * scale). `my`/`enemy` are player indices. */
+export interface FixedGame {
+  my: number;
+  enemy: number;
+  kind: 'my-defends' | 'enemy-defends' | 'refused' | 'last';
+  value: number;
+  round: number;
+}
+
+/** A decision I made, with the regret it carries (docs/web-design.md §3.4). */
+export interface DraftDecision {
+  stage: 'defender' | 'attackers' | 'refusal';
+  round: number;
+  chosenId: number | [number, number];
+  chosenName: string | [string, string];
+  chosenEv: number;
+  bestEv: number;
+  /** Name of the max-EV option (what the equilibrium would have played). */
+  bestName: string | [string, string];
+  /** max(choices.ev) − ev(chosen); ≥ 0 up to LP tolerance. */
+  regret: number;
+}
+
+export interface DraftModel {
+  n: number;
+  matrix: Matrix;
+  neutralWeight: number;
+  /** The move path to feed engine.nodeResult(). */
+  path: Move[];
+  round: number;
+  finalRound: number;
+  /** Ascending pools at the current point (refused attackers stay in). */
+  myRemaining: number[];
+  enemyRemaining: number[];
+  // in-progress round scratch (−1 / null between rounds)
+  myDefender: number;
+  enemyDefender: number;
+  myPair: [number, number] | null;
+  enemyPair: [number, number] | null;
+  fixed: FixedGame[];
+  decisions: DraftDecision[];
+  done: boolean;
+}
+
+const range = (n: number): number[] => Array.from({ length: n }, (_, i) => i);
+
+function combinations(items: number[]): [number, number][] {
+  const pairs: [number, number][] = [];
+  for (let i = 0; i < items.length - 1; i++) {
+    for (let j = i + 1; j < items.length; j++) pairs.push([items[i], items[j]]);
+  }
+  return pairs;
+}
+
+export function initDraft(matrix: Matrix, neutralWeight: number): DraftModel {
+  const n = matrix.n;
+  return {
+    n,
+    matrix,
+    neutralWeight,
+    path: [],
+    round: 1,
+    finalRound: (n - 4) / 2 + 1,
+    myRemaining: range(n),
+    enemyRemaining: range(n),
+    myDefender: -1,
+    enemyDefender: -1,
+    myPair: null,
+    enemyPair: null,
+    fixed: [],
+    decisions: [],
+    done: false,
+  };
+}
+
+/** Map the bot's sampled column index (into node.why.enStrategy) to the enemy's
+ * move id, using the exact-mode ascending enumeration the engine uses
+ * (nodeResult.test.ts). Refusal columns are my just-sent attacker pair. */
+export function enemyMoveId(model: DraftModel, stage: NodeResult['stage'], colIndex: number): number | [number, number] {
+  if (stage === 'defender') return model.enemyRemaining[colIndex];
+  if (stage === 'attackers') {
+    const eligible = model.enemyRemaining.filter((x) => x !== model.enemyDefender);
+    return combinations(eligible)[colIndex];
+  }
+  return model.myPair![colIndex]; // refusal: enemy refuses one of MY attackers
+}
+
+function matchupValue(model: DraftModel, kind: FixedGame['kind'], my: number, enemy: number): number {
+  const cell = model.matrix.cells[my][enemy];
+  if (kind === 'my-defends') return cell.best; // I defend → my best map
+  if (kind === 'enemy-defends') return cell.worst; // enemy defends → my worst map
+  return cell.worst + model.neutralWeight * (cell.best - cell.worst); // refused / last → neutral
+}
+
+/** Apply one simultaneous decision: my choice (index into node.choices) + the
+ * bot's sampled enemy column (index into node.why.enStrategy). Returns a new
+ * model (the input is not mutated). At the refusal step it resolves the round's
+ * fixed games and, on the final round, the refused-vs-refused and last-vs-last
+ * games. */
+export function applyStep(model: DraftModel, node: NodeResult, myIndex: number, colIndex: number): DraftModel {
+  const choice = node.choices[myIndex];
+  const bestChoice = node.choices.reduce((best, c) => (c.ev > best.ev ? c : best), node.choices[0]);
+  const bestEv = bestChoice.ev;
+  const decision: DraftDecision = {
+    stage: node.stage as DraftDecision['stage'],
+    round: model.round,
+    chosenId: choice.id,
+    chosenName: choice.name,
+    chosenEv: choice.ev,
+    bestEv,
+    bestName: bestChoice.name,
+    regret: bestEv - choice.ev,
+  };
+
+  const next: DraftModel = {
+    ...model,
+    path: [...model.path],
+    myRemaining: [...model.myRemaining],
+    enemyRemaining: [...model.enemyRemaining],
+    fixed: [...model.fixed],
+    decisions: [...model.decisions, decision],
+  };
+
+  if (node.stage === 'defender') {
+    const my = choice.id as number;
+    const enemy = enemyMoveId(model, 'defender', colIndex) as number;
+    next.path.push({ stage: 'defender', my, enemy });
+    next.myDefender = my;
+    next.enemyDefender = enemy;
+  } else if (node.stage === 'attackers') {
+    const my = choice.id as [number, number];
+    const enemy = enemyMoveId(model, 'attackers', colIndex) as [number, number];
+    next.path.push({ stage: 'attackers', my, enemy });
+    next.myPair = my;
+    next.enemyPair = enemy;
+  } else {
+    // refusal: choice.id = the ENEMY attacker I refuse (Move.my);
+    // enemyMoveId = the FRIENDLY attacker the enemy refuses (Move.enemy).
+    const iRefuse = choice.id as number;
+    const enemyRefuses = enemyMoveId(model, 'refusal', colIndex) as number;
+    next.path.push({ stage: 'refusal', my: iRefuse, enemy: enemyRefuses });
+    resolveRound(next, iRefuse, enemyRefuses);
+  }
+
+  return next;
+}
+
+/** Fix the round's games and advance (mutates the already-copied `next`). */
+function resolveRound(next: DraftModel, iRefuse: number, enemyRefuses: number): void {
+  const [fa, fb] = next.myPair!;
+  const [ea, eb] = next.enemyPair!;
+  const myKept = fa === enemyRefuses ? fb : fa; // enemy refused one of mine → keep the other
+  const enemyKept = ea === iRefuse ? eb : ea; // I refused one of theirs → they keep the other
+  const round = next.round;
+
+  next.fixed.push(
+    {
+      my: next.myDefender, enemy: enemyKept, kind: 'my-defends', round,
+      value: matchupValue(next, 'my-defends', next.myDefender, enemyKept),
+    },
+    {
+      my: myKept, enemy: next.enemyDefender, kind: 'enemy-defends', round,
+      value: matchupValue(next, 'enemy-defends', myKept, next.enemyDefender),
+    },
+  );
+
+  next.myRemaining = next.myRemaining.filter((x) => x !== next.myDefender && x !== myKept);
+  next.enemyRemaining = next.enemyRemaining.filter((x) => x !== next.enemyDefender && x !== enemyKept);
+
+  if (round === next.finalRound) {
+    const myRefused = enemyRefuses; // my attacker the enemy refused
+    const enemyRefused = iRefuse; // enemy attacker I refused
+    const myLast = next.myRemaining.find((x) => x !== myRefused)!;
+    const enemyLast = next.enemyRemaining.find((x) => x !== enemyRefused)!;
+    next.fixed.push(
+      {
+        my: myRefused, enemy: enemyRefused, kind: 'refused', round,
+        value: matchupValue(next, 'refused', myRefused, enemyRefused),
+      },
+      {
+        my: myLast, enemy: enemyLast, kind: 'last', round,
+        value: matchupValue(next, 'last', myLast, enemyLast),
+      },
+    );
+    next.done = true;
+  } else {
+    next.round = round + 1;
+    next.myDefender = -1;
+    next.enemyDefender = -1;
+    next.myPair = null;
+    next.enemyPair = null;
+  }
+}
+
+/** Total achieved team result (internal scale) = sum of the fixed games. */
+export function achievedTotal(model: DraftModel): number {
+  return model.fixed.reduce((sum, game) => sum + game.value, 0);
+}

--- a/web/src/draft/sampling.test.ts
+++ b/web/src/draft/sampling.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'vitest';
+import { sampleIndex } from './sampling';
+
+describe('sampleIndex', () => {
+  test('greedy picks the argmax probability', () => {
+    expect(sampleIndex([0.2, 0.5, 0.3], 'greedy')).toBe(1);
+    expect(sampleIndex([0.6, 0.4], 'greedy')).toBe(0);
+  });
+
+  test('equilibrium samples from the cumulative distribution', () => {
+    const probs = [0.5, 0.0, 0.5];
+    expect(sampleIndex(probs, 'equilibrium', () => 0)).toBe(0); // first positive-prob bucket
+    expect(sampleIndex(probs, 'equilibrium', () => 0.75)).toBe(2); // past the first 0.5
+    expect(sampleIndex(probs, 'equilibrium', () => 0.999)).toBe(2); // last positive bucket
+  });
+
+  test('equilibrium never lands on a zero-probability option', () => {
+    const probs = [0.0, 1.0, 0.0];
+    for (const r of [0, 0.3, 0.6, 0.999]) {
+      expect(sampleIndex(probs, 'equilibrium', () => r)).toBe(1);
+    }
+  });
+
+  test('wildcard flattens, so a low-prob option can be picked where equilibrium would not', () => {
+    const probs = [0.95, 0.05];
+    // At r just below 0.95, equilibrium picks index 0; wildcard's flattened
+    // distribution gives index 1 a much wider band, so it's chosen here.
+    expect(sampleIndex(probs, 'equilibrium', () => 0.9)).toBe(0);
+    expect(sampleIndex(probs, 'wildcard', () => 0.9)).toBe(1);
+  });
+});

--- a/web/src/draft/sampling.ts
+++ b/web/src/draft/sampling.ts
@@ -1,0 +1,41 @@
+/** Bot styles (docs/web-design.md §3.3) — pure client-side transforms of the
+ * engine's true equilibrium strategy. The engine only ever returns the
+ * equilibrium; the UI samples it. */
+export type BotStyle = 'equilibrium' | 'greedy' | 'wildcard';
+
+/** Wildcard temperature: >1 flattens the distribution toward uniform, so the
+ * bot occasionally makes off-equilibrium picks a human might not expect. */
+const WILDCARD_TEMPERATURE = 2;
+
+function argmax(values: number[]): number {
+  let best = 0;
+  for (let i = 1; i < values.length; i++) if (values[i] > values[best]) best = i;
+  return best;
+}
+
+/** Temperature-flatten: pᵢ^(1/T) renormalised. */
+function flatten(probs: number[], temperature: number): number[] {
+  const raised = probs.map((p) => Math.pow(Math.max(0, p), 1 / temperature));
+  const total = raised.reduce((sum, w) => sum + w, 0);
+  return total > 0 ? raised.map((w) => w / total) : probs;
+}
+
+/** Pick a bucket index by walking the cumulative distribution; zero-weight
+ * buckets are never selected. */
+function sampleFrom(weights: number[], rng: () => number): number {
+  const r = rng();
+  let cumulative = 0;
+  for (let i = 0; i < weights.length; i++) {
+    cumulative += weights[i];
+    if (r < cumulative) return i;
+  }
+  return weights.length - 1; // floating-point fallthrough → last non-empty bucket
+}
+
+/** Choose an option index from an equilibrium probability vector under the
+ * given bot style. `rng` is injectable for deterministic tests. */
+export function sampleIndex(probs: number[], style: BotStyle, rng: () => number = Math.random): number {
+  if (style === 'greedy') return argmax(probs);
+  const weights = style === 'wildcard' ? flatten(probs, WILDCARD_TEMPERATURE) : probs;
+  return sampleFrom(weights, rng);
+}

--- a/web/src/draft/summary.test.ts
+++ b/web/src/draft/summary.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'vitest';
+import type { DraftDecision } from './draftState';
+import { decompose, verdict } from './summary';
+
+function decision(regret: number): DraftDecision {
+  return {
+    stage: 'attackers', round: 1,
+    chosenId: [0, 1], chosenName: ['A', 'B'], chosenEv: 5 - regret,
+    bestEv: 5, bestName: ['A', 'C'], regret,
+  };
+}
+
+describe('decompose (§3.4)', () => {
+  test('splits the delta into regret (my picks) and variance (reveal luck)', () => {
+    const d = decompose([decision(0), decision(2), decision(0)], 5, 4);
+    expect(d.totalRegret).toBeCloseTo(2, 9);
+    expect(d.totalDelta).toBeCloseTo(-1, 9); // achieved 4 − expected 5
+    expect(d.variance).toBeCloseTo(1, 9); // totalDelta + Σregret = −1 + 2
+    expect(d.leaks).toHaveLength(1);
+    expect(d.leaks[0].regret).toBe(2);
+  });
+
+  test('the decomposition sums exactly: achieved = expected + variance − Σregret', () => {
+    const d = decompose([decision(1.5), decision(0.5)], 6.2, 3.1);
+    expect(d.expected + d.variance - d.totalRegret).toBeCloseTo(d.achieved, 9);
+  });
+
+  test('clamps tiny negative regrets (LP tolerance) to zero', () => {
+    const d = decompose([decision(-1e-12)], 5, 5);
+    expect(d.totalRegret).toBe(0);
+    expect(d.leaks).toHaveLength(0);
+  });
+});
+
+describe('verdict', () => {
+  test('clean draft credits/blames variance, never the bot', () => {
+    const clean = decompose([decision(0)], 5, 3); // regret 0, variance −2
+    expect(verdict(83, 77, clean).summary).toMatch(/unlucky reveals/i);
+
+    const onPlan = decompose([decision(0)], 5, 5);
+    expect(verdict(85, 75, onPlan).summary).toMatch(/went to plan/i);
+
+    const lucky = decompose([decision(0)], 5, 8);
+    expect(verdict(88, 72, lucky).summary).toMatch(/broke your way|reveals/i);
+  });
+
+  test('a leaky draft says the picks cost points', () => {
+    const leaky = decompose([decision(3)], 5, 2);
+    expect(verdict(82, 78, leaky).summary).toMatch(/picks cost/i);
+    expect(verdict(82, 78, leaky).summary).not.toMatch(/out-drafted/i);
+  });
+
+  test('result label reflects the achieved margin', () => {
+    const d = decompose([], 0, 0);
+    expect(verdict(120, 40, d).result).toBe('CRUSHING WIN');
+    expect(verdict(86, 74, d).result).toBe('CLOSE WIN');
+    expect(verdict(80, 80, d).result).toBe('DEAD DRAW');
+    expect(verdict(70, 90, d).result).toBe('LARGE LOSS');
+  });
+});

--- a/web/src/draft/summary.ts
+++ b/web/src/draft/summary.ts
@@ -1,0 +1,62 @@
+import type { DraftDecision } from './draftState';
+
+const REGRET_TOL = 1e-6;
+/** A draft is "clean" below ~1 point of total leaks (the ±1 verdict band, §C). */
+const CLEAN_THRESHOLD = 1;
+
+export interface Decomposition {
+  expected: number;
+  achieved: number;
+  /** achieved − expected. */
+  totalDelta: number;
+  /** Σ max(0, regret) over my decisions — points I left on the table. */
+  totalRegret: number;
+  /** totalDelta + totalRegret — reveal luck (which branch of its mix the bot
+   * sampled). Per §3.4; the issue #21 comment's minus sign is a slip. */
+  variance: number;
+  /** My non-zero-regret decisions, worst-first. */
+  leaks: DraftDecision[];
+}
+
+/** Split the delta-vs-plan into my regret and the reveal variance (§3.4). */
+export function decompose(decisions: DraftDecision[], expected: number, achieved: number): Decomposition {
+  const totalRegret = decisions.reduce((sum, d) => sum + Math.max(0, d.regret), 0);
+  const totalDelta = achieved - expected;
+  const variance = totalDelta + totalRegret;
+  const leaks = decisions
+    .filter((d) => d.regret > REGRET_TOL)
+    .sort((a, b) => b.regret - a.regret);
+  return { expected, achieved, totalDelta, totalRegret, variance, leaks };
+}
+
+export interface Verdict {
+  /** Magnitude of the achieved team result. */
+  result: string;
+  /** The regret/variance sentence (never blames the bot when the draft is clean). */
+  summary: string;
+}
+
+function resultLabel(margin: number): string {
+  if (margin >= 40) return 'CRUSHING WIN';
+  if (margin >= 16) return 'LARGE WIN';
+  if (margin >= 1) return 'CLOSE WIN';
+  if (margin === 0) return 'DEAD DRAW';
+  if (margin >= -15) return 'CLOSE LOSS';
+  if (margin >= -39) return 'LARGE LOSS';
+  return 'CRUSHING LOSS';
+}
+
+function summaryCopy(d: Decomposition): string {
+  const v = Math.round(d.variance);
+  if (d.totalRegret < CLEAN_THRESHOLD) {
+    if (v > 0) return `Perfect picks, and the reveals broke your way — variance +${v}.`;
+    if (v < 0) return `Clean draft — unlucky reveals, variance ${v}.`;
+    return 'Clean draft — it went to plan.';
+  }
+  const varPart = v > 0 ? ` Variance still added +${v}.` : v < 0 ? ` Variance took another ${v}.` : '';
+  return `Your picks cost ${d.totalRegret.toFixed(1)} vs the equilibrium.${varPart}`;
+}
+
+export function verdict(myScore: number, enemyScore: number, decomposition: Decomposition): Verdict {
+  return { result: resultLabel(myScore - enemyScore), summary: summaryCopy(decomposition) };
+}

--- a/web/src/model/scale.test.ts
+++ b/web/src/model/scale.test.ts
@@ -60,14 +60,20 @@ describe('toInputString', () => {
 });
 
 describe('teamResult', () => {
-  test('maps the internal margin to a 0-160 team score (80 + margin)', () => {
-    expect(teamResult(5)).toEqual({ my: 85, enemy: 75, favored: 5 });
-    expect(teamResult(0)).toEqual({ my: 80, enemy: 80, favored: 0 });
-    expect(teamResult(-3)).toEqual({ my: 77, enemy: 83, favored: -3 });
+  test('maps the internal margin to a team score at the 10n-per-side baseline', () => {
+    expect(teamResult(5, 8)).toEqual({ my: 85, enemy: 75, favored: 5 });
+    expect(teamResult(0, 8)).toEqual({ my: 80, enemy: 80, favored: 0 });
+    expect(teamResult(-3, 8)).toEqual({ my: 77, enemy: 83, favored: -3 });
   });
 
-  test('rounds and keeps the two scores summing to 160', () => {
-    const r = teamResult(6.189614);
+  test('scales the baseline with team size (6 → /120, 4 → /80)', () => {
+    expect(teamResult(3, 6)).toEqual({ my: 63, enemy: 57, favored: 3 });
+    expect(teamResult(0, 6)).toEqual({ my: 60, enemy: 60, favored: 0 });
+    expect(teamResult(0, 4)).toEqual({ my: 40, enemy: 40, favored: 0 });
+  });
+
+  test('rounds and keeps the two scores summing to 20n', () => {
+    const r = teamResult(6.189614, 8);
     expect(r.my).toBe(86);
     expect(r.enemy).toBe(74);
     expect(r.my + r.enemy).toBe(160);

--- a/web/src/model/scale.ts
+++ b/web/src/model/scale.ts
@@ -44,20 +44,22 @@ export const formatCell = (cell: { best: number; worst: number }): string =>
   `${toScore(cell.best)} / ${toScore(cell.worst)}`;
 
 export interface TeamResult {
-  /** My team's total out of 160. */
+  /** My team's total out of 20n. */
   my: number;
-  /** Opponent's total out of 160. */
+  /** Opponent's total out of 20n. */
   enemy: number;
   /** My margin over even (= expected internal margin, rounded). */
   favored: number;
 }
 
-/** Convert the engine's internal team margin (sum of 8 games' deviations) to a
- * displayed 0-160 team result: my = 80 + margin, enemy = 160 - my. The two
- * always sum to 160 (§C, PLAN.md). */
-export function teamResult(expected: number): TeamResult {
-  const my = Math.round(80 + expected);
-  return { my, enemy: 160 - my, favored: my - 80 };
+/** Convert the engine's internal team margin (sum of n games' deviations) to a
+ * displayed team result on the community scale: n games out of 20 → 20n total,
+ * even split 10n each, so my = 10n + margin and enemy = 20n − my (§C, PLAN.md).
+ * The two always sum to 20n. */
+export function teamResult(expected: number, n: number): TeamResult {
+  const even = 10 * n;
+  const my = Math.round(even + expected);
+  return { my, enemy: 2 * even - my, favored: my - even };
 }
 
 export type ScoreBand = 'worst' | 'bad' | 'okay' | 'good' | 'best';

--- a/web/src/worker/useSolve.ts
+++ b/web/src/worker/useSolve.ts
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react';
-import type { SolvedEvent } from '../engine/types';
+import type { Move, NodeResult, SolvedEvent } from '../engine/types';
 import type { EditorMatrix } from '../model/matrix';
 import { toEngineMatrix } from '../model/matrix';
 import { WorkerClient } from './client';
@@ -12,8 +12,13 @@ export interface SolveState {
   phase: 'enumerating' | 'inducting' | null;
   result: SolvedEvent | null;
   error: string | null;
+  /** The k of the completed solve (null = exact); undefined before any solve. */
+  solvedK: number | null | undefined;
   /** k = null → exact; k = 3 → fast preview (§7). */
   solve: (matrix: EditorMatrix, k: number | null) => void;
+  /** Query one draft node from the solved values (instant). The trainer uses
+   * this; it rejects if nothing is solved. */
+  node: (path: Move[]) => Promise<NodeResult>;
   reset: () => void;
 }
 
@@ -31,6 +36,7 @@ export function useSolve(makeClient: () => WorkerClient = () => new WorkerClient
   const [phase, setPhase] = useState<'enumerating' | 'inducting' | null>(null);
   const [result, setResult] = useState<SolvedEvent | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [solvedK, setSolvedK] = useState<number | null | undefined>(undefined);
 
   const client = () => {
     if (!clientRef.current) clientRef.current = makeClient();
@@ -61,6 +67,7 @@ export function useSolve(makeClient: () => WorkerClient = () => new WorkerClient
       .then((solved) => {
         if (gen !== genRef.current) return;
         setResult(solved);
+        setSolvedK(k);
         setProgress(1);
         setStatus('done');
       })
@@ -71,6 +78,11 @@ export function useSolve(makeClient: () => WorkerClient = () => new WorkerClient
       });
   };
 
+  const node = (path: Move[]): Promise<NodeResult> =>
+    clientRef.current
+      ? clientRef.current.node(path)
+      : Promise.reject(new Error('No solved matrix; solve first.'));
+
   const reset = () => {
     genRef.current++;
     setStatus('idle');
@@ -78,8 +90,9 @@ export function useSolve(makeClient: () => WorkerClient = () => new WorkerClient
     setPhase(null);
     setResult(null);
     setError(null);
+    setSolvedK(undefined);
     clientRef.current?.reset().catch(() => {});
   };
 
-  return { status, progress, phase, result, error, solve, reset };
+  return { status, progress, phase, result, error, solvedK, solve, node, reset };
 }


### PR DESCRIPTION
Closes #21. The final M4 slice: a NodeResult-driven draft loop against the bot, plus the regret/variance summary. Engine/worker unchanged (§3.3/§3.4 built purely in the UI).

## What's here
- **`draft/sampling`** — bot styles (equilibrium / greedy / wildcard) as pure client-side transforms of the true equilibrium (§3.3); seedable RNG.
- **`draft/draftState`** — the draft loop: builds the `Move` path, recovers the bot's enemy-move id from `why.enStrategy` (exact-mode ascending enumeration + the just-sent pair, per `nodeResult.test.ts`), reconstructs the fixed pairings with best/worst/neutral value-model values, and supports undo. **Runs on the exact solve** (so enemy enumeration is ascending, no k-restriction ambiguity).
- **`draft/summary`** — the §3.4 decomposition: `variance = totalDelta + Σregret`, regrets clamped ≥ 0, sums exactly; verdict copy that credits/blames variance on a clean draft and **never** says the bot out-drafted you. (The issue comment's `− Σregret` is a sign slip; the invariants pin the `+`.)
- **`DraftTrainer`** — round/stage flow with the mockup's copy, equilibrium strategy + EV hints, bot-style selector, Hints/Undo, simultaneous reveal, the **Why panel** (payoff matrix + both mixes), and a locked-pairings tracker. **`DraftSummary`** — result label, regret/variance metrics, worst-first leak list, final pairings with per-game scores.
- **`useSolve`** gains `node()` + `solvedK`; **App** enables the Trainer tab and re-solves exact on entry.

## Verification
- `typecheck` clean; `npm test` **83 passed / 1 skipped** under `CONFORMANCE_SLOW=1` (engine values unchanged). Logic is TDD'd against the real Smoke engine (pairing reconstruction, values, regret ≥ 0); a component test plays a full 4×4 draft to the summary and exercises undo.
- **In-browser, real worker** — a full **Scotland 8-player draft** vs the bot plays through all 3 rounds to the summary. The opening defender mix in the trainer (**Mariusz 86% / Petter 14%**) matches the Solve view exactly. The summary decomposition sums exactly (achieved margin −5 = expected +6 + variance +4.5 − regret 15.5) and the worst-first leak list renders ("R1 attackers — sent Kjetil + Magnus · best Mariusz + Patrick · −4.6"). No console errors on a clean load.

_(Screenshots of the decision + summary screens were captured during verification; preview-tool screenshots only work on static screens this session, so mid-animation shots are DOM-verified instead.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)