### PR TITLE
M5 PR2: rebuild the Trainer as the design's draft board (P1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ dist/
 # web app (docs/web-design.md §9)
 web/node_modules/
 web/dist/
+# stray vite cache when vitest runs from the repo root
+/node_modules/

--- a/web/src/components/DraftBoard.test.tsx
+++ b/web/src/components/DraftBoard.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { render, within } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import { fixtureMatrix, smoke } from '../conformance/fixtures';
+import { initDraft } from '../draft/draftState';
+import { DraftBoard } from './DraftBoard';
+
+describe('DraftBoard', () => {
+  test('defender stage: our defender is selecting…, their defender hidden', () => {
+    const matrix = fixtureMatrix(smoke);
+    const model = initDraft(matrix, smoke.neutralWeight);
+    const { container } = render(
+      <DraftBoard model={model} myNames={matrix.myNames} enemyNames={matrix.enemyNames} stage="defender" />,
+    );
+    const q = within(container);
+
+    expect(q.getByText(/Our defender/i)).toBeInTheDocument();
+    expect(q.getByText(/Their defender/i)).toBeInTheDocument();
+    expect(q.getByText('selecting…')).toBeInTheDocument();
+    expect(q.getByText(/Their two attackers will land here/i)).toBeInTheDocument();
+    expect(q.getByText(/Your two attackers will land here/i)).toBeInTheDocument();
+  });
+
+  test('fills locked defenders and attackers from the model', () => {
+    const matrix = fixtureMatrix(smoke);
+    const base = initDraft(matrix, smoke.neutralWeight);
+    const model = {
+      ...base,
+      myDefender: 0,
+      enemyDefender: 1,
+      myPair: [2, 3] as [number, number],
+      enemyPair: [1, 2] as [number, number],
+    };
+    const { container } = render(
+      <DraftBoard model={model} myNames={matrix.myNames} enemyNames={matrix.enemyNames} stage="refusal" />,
+    );
+    const q = within(container);
+
+    expect(q.getByText(matrix.myNames[0])).toBeInTheDocument(); // our defender
+    expect(q.getByText(matrix.myNames[2])).toBeInTheDocument(); // our attacker
+    expect(q.queryByText('selecting…')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/DraftBoard.tsx
+++ b/web/src/components/DraftBoard.tsx
@@ -1,0 +1,58 @@
+import type { DraftModel } from '../draft/draftState';
+
+interface DraftBoardProps {
+  model: DraftModel;
+  myNames: string[];
+  enemyNames: string[];
+  /** The current decision, so the slot being chosen can highlight. */
+  stage: 'defender' | 'attackers' | 'refusal';
+}
+
+/** The two-panel draft board (docs/design-mockup.html "Trainer"): each side's
+ * defender flanked by the two opposing attackers that land on it. Everything is
+ * read from the in-progress round scratch on `DraftModel`; unknown picks show
+ * `selecting…` (ours, in progress), `?` (theirs, hidden), or `—` (not sent
+ * yet). "our/their map" are conceptual labels — the value model folds the map
+ * choice into best/worst rather than naming maps. */
+export function DraftBoard({ model, myNames, enemyNames, stage }: DraftBoardProps) {
+  const myDef = model.myDefender >= 0 ? myNames[model.myDefender] : null;
+  const enDef = model.enemyDefender >= 0 ? enemyNames[model.enemyDefender] : null;
+  const enAtk = model.enemyPair ? (model.enemyPair.map((i) => enemyNames[i]) as [string, string]) : null;
+  const myAtk = model.myPair ? (model.myPair.map((i) => myNames[i]) as [string, string]) : null;
+
+  return (
+    <div className="draft-board">
+      <div className="board-panel">
+        <div className="board-title">Our defender · our map</div>
+        <div className={`slot def mine${myDef ? ' filled' : ' pending'}${!myDef && stage === 'defender' ? ' active' : ''}`}>
+          <span className="slot-tag">DEF</span>
+          <span className="slot-name">{myDef ?? 'selecting…'}</span>
+        </div>
+        <div className="slot-pair">
+          {(enAtk ?? [null, null]).map((name, i) => (
+            <div key={i} className={`slot atk enemy${name ? ' filled' : ' hidden'}${!enAtk && stage === 'refusal' ? ' active' : ''}`}>
+              <span className="slot-name">{name ?? '?'}</span>
+            </div>
+          ))}
+        </div>
+        {!enAtk && <div className="board-hint">Their two attackers will land here</div>}
+      </div>
+
+      <div className="board-panel">
+        <div className="board-title">Their defender · their map</div>
+        <div className={`slot def enemy${enDef ? ' filled' : ' hidden'}`}>
+          <span className="slot-tag">DEF</span>
+          <span className="slot-name">{enDef ?? '?'}</span>
+        </div>
+        <div className="slot-pair">
+          {(myAtk ?? [null, null]).map((name, i) => (
+            <div key={i} className={`slot atk mine${name ? ' filled' : ' empty'}${!myAtk && stage === 'attackers' ? ' active' : ''}`}>
+              <span className="slot-name">{name ?? '—'}</span>
+            </div>
+          ))}
+        </div>
+        {!myAtk && <div className="board-hint">Your two attackers will land here</div>}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/DraftTrainer.test.tsx
+++ b/web/src/components/DraftTrainer.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, test, vi } from 'vitest';
 import { fixtureMatrix, smoke } from '../conformance/fixtures';
@@ -43,7 +43,13 @@ describe('DraftTrainer (Smoke 4×4, real engine)', () => {
       />,
     );
 
+    // The intro restores the privacy / WTC-lock bullet.
+    expect(within(container).getByText(/never uploaded/i)).toBeInTheDocument();
+
     await user.click(await screen.findByRole('button', { name: /Start practice draft/ }));
+
+    // The draft board renders for the active round.
+    expect(await within(container).findByText(/Our defender · our map/i)).toBeInTheDocument();
 
     // A 4×4 draft is one round: defender → attackers → refusal.
     for (let step = 0; step < 3; step++) {

--- a/web/src/components/DraftTrainer.tsx
+++ b/web/src/components/DraftTrainer.tsx
@@ -210,7 +210,7 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
         <span className="muted">{enemy} picks simultaneously — revealed after you lock.</span>
       </div>
 
-      {showWhy && hintsAllowed && <WhyPanel node={node} />}
+      {showWhy && hintsAllowed && <WhyPanel node={node} model={model} myNames={myNames} enemyNames={enemyNames} />}
 
       {model.fixed.length > 0 && (
         <div className="locked">

--- a/web/src/components/DraftTrainer.tsx
+++ b/web/src/components/DraftTrainer.tsx
@@ -5,7 +5,7 @@ import { sampleIndex } from '../draft/sampling';
 import type { DraftModel } from '../draft/draftState';
 import { applyStep, initDraft } from '../draft/draftState';
 import { candidateStats, projectedResult } from '../draft/cards';
-import { teamResult, toScore } from '../model/scale';
+import { formatTeamScore, teamTotal, toScore } from '../model/scale';
 import { activeWtcEvent } from '../model/wtcDates';
 import type { SolveState } from '../worker/useSolve';
 import { DraftBoard } from './DraftBoard';
@@ -115,7 +115,10 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
   if (stage !== modelStage) return <p className="placeholder">Loading the next decision…</p>;
   const copy = STAGE_COPY[stage];
   const proj = projectedResult(model, node, expected);
-  const projScore = teamResult(proj.projected, model.n).my;
+  // EV cards + the projected header share one scale: the 0–20n team total, one
+  // decimal. The best card's EV therefore equals the projected figure exactly.
+  const achieved = model.fixed.reduce((sum, g) => sum + g.value, 0);
+  const projScore = formatTeamScore(teamTotal(proj.projected, model.n));
 
   const lock = () => {
     if (selected === null || !node.why) return;
@@ -228,7 +231,7 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
                 <span className="chint">
                   <span className="cbar"><span style={{ width: `${Math.min(100, choice.prob * 100)}%` }} /></span>
                   <span className="cprob">{(choice.prob * 100).toFixed(0)}%</span>
-                  <span className="cev">{choice.ev >= 0 ? '+' : ''}{choice.ev.toFixed(1)}</span>
+                  <span className="cev">EV {formatTeamScore(teamTotal(achieved + choice.ev, model.n))}</span>
                 </span>
               )}
             </button>

--- a/web/src/components/DraftTrainer.tsx
+++ b/web/src/components/DraftTrainer.tsx
@@ -4,11 +4,15 @@ import type { BotStyle } from '../draft/sampling';
 import { sampleIndex } from '../draft/sampling';
 import type { DraftModel } from '../draft/draftState';
 import { applyStep, initDraft } from '../draft/draftState';
-import { toScore } from '../model/scale';
+import { candidateStats, projectedResult } from '../draft/cards';
+import { teamResult, toScore } from '../model/scale';
 import { activeWtcEvent } from '../model/wtcDates';
 import type { SolveState } from '../worker/useSolve';
+import { DraftBoard } from './DraftBoard';
 import { DraftSummary } from './DraftSummary';
+import { PhaseStepper } from './PhaseStepper';
 import { ProgressBar } from './ProgressBar';
+import { RemainingMatchups } from './RemainingMatchups';
 import { WhyPanel } from './WhyPanel';
 import './trainer.css';
 
@@ -76,6 +80,7 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
           <li>Round {finalRound} — four players: the two refused attackers face each other and the last players pair automatically, resolving the remaining games.</li>
           <li>Both captains pick secretly at every step. The bot's choice is revealed only after you lock yours.</li>
           <li>At the end you're scored against the solver's pre-draft expectation.</li>
+          <li>Runs entirely on your computer — your matrix and drafts are never uploaded. Hints are training-only and switch off during official WTC dates.</li>
         </ul>
         {solve.status === 'solving' && <ProgressBar frac={solve.progress} label="Solving exactly for training…" />}
         <button className="primary" disabled={!ready} onClick={start}>Start practice draft</button>
@@ -102,7 +107,15 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
   if (!node) return <p className="placeholder">Loading the next decision…</p>;
 
   const stage = node.stage as 'defender' | 'attackers' | 'refusal';
+  // `node` is fetched asynchronously, so during an advance or undo the model's
+  // round scratch can briefly disagree with the stale node. Wait for them to
+  // re-sync before reading model-derived card stats / board slots (otherwise
+  // candidateStats would index an unset defender or pair).
+  const modelStage = model.myDefender < 0 ? 'defender' : model.myPair === null ? 'attackers' : 'refusal';
+  if (stage !== modelStage) return <p className="placeholder">Loading the next decision…</p>;
   const copy = STAGE_COPY[stage];
+  const proj = projectedResult(model, node, expected);
+  const projScore = teamResult(proj.projected, model.n).my;
 
   const lock = () => {
     if (selected === null || !node.why) return;
@@ -136,9 +149,19 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
 
   return (
     <div className="trainer">
+      <PhaseStepper stage={stage} />
       <div className="trainer-head">
         <h2>{copy.title}</h2>
         <span className="round-badge">Round {node.round} / {finalRound}</span>
+        {showHints && (
+          <span className="projected">
+            Projected <span className="pnum">{projScore}</span>{' '}
+            <span className={proj.delta >= 0 ? 'pdelta up' : 'pdelta down'}>
+              {proj.delta >= 0 ? '+' : ''}
+              {proj.delta.toFixed(1)} vs plan
+            </span>
+          </span>
+        )}
       </div>
       <p className="trainer-sub">{copy.sub}</p>
 
@@ -184,25 +207,33 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
         </div>
       )}
 
-      <div className="choices">
-        {node.choices.map((choice, i) => (
-          <button
-            key={i}
-            className={selected === i ? 'choice selected' : 'choice'}
-            onClick={() => setSelected(i)}
-          >
-            <span className="cname">
-              {stage === 'refusal' ? `Refuse ${joinName(choice.name)}` : joinName(choice.name)}
-            </span>
-            {showHints && (
-              <>
-                <span className="cbar"><span style={{ width: `${Math.min(100, choice.prob * 100)}%` }} /></span>
-                <span className="cprob">{(choice.prob * 100).toFixed(0)}%</span>
-                <span className="cev">{choice.ev >= 0 ? '+' : ''}{choice.ev.toFixed(1)}</span>
-              </>
-            )}
-          </button>
-        ))}
+      <DraftBoard model={model} myNames={myNames} enemyNames={enemyNames} stage={stage} />
+
+      <div className="choices grid">
+        {node.choices.map((choice, i) => {
+          const stats = candidateStats(model, node, i);
+          return (
+            <button
+              key={i}
+              className={selected === i ? 'choice selected' : 'choice'}
+              onClick={() => setSelected(i)}
+            >
+              <span className="cname">
+                {stage === 'refusal' ? `Refuse ${joinName(choice.name)}` : joinName(choice.name)}
+              </span>
+              <span className="cstat">
+                our map · {stats.avg === stats.floor ? `keeps ${stats.avg}` : `avg ${stats.avg} · floor ${stats.floor}`}
+              </span>
+              {showHints && (
+                <span className="chint">
+                  <span className="cbar"><span style={{ width: `${Math.min(100, choice.prob * 100)}%` }} /></span>
+                  <span className="cprob">{(choice.prob * 100).toFixed(0)}%</span>
+                  <span className="cev">{choice.ev >= 0 ? '+' : ''}{choice.ev.toFixed(1)}</span>
+                </span>
+              )}
+            </button>
+          );
+        })}
       </div>
 
       <div className="lock-bar">
@@ -212,9 +243,13 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
 
       {showWhy && hintsAllowed && <WhyPanel node={node} model={model} myNames={myNames} enemyNames={enemyNames} />}
 
-      {model.fixed.length > 0 && (
-        <div className="locked">
-          <div className="section-head">Locked pairings ({model.fixed.length})</div>
+      <RemainingMatchups model={model} myNames={myNames} enemyNames={enemyNames} />
+
+      <div className="locked">
+        <div className="section-head">Locked pairings ({model.fixed.length})</div>
+        {model.fixed.length === 0 ? (
+          <div className="pairing placeholder-pairing">{model.n} pairings remaining</div>
+        ) : (
           <div className="locked-list">
             {model.fixed.map((game, i) => {
               const my = toScore(game.value);
@@ -227,8 +262,8 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
               );
             })}
           </div>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 }

--- a/web/src/components/PhaseStepper.test.tsx
+++ b/web/src/components/PhaseStepper.test.tsx
@@ -1,0 +1,13 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { render, within } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { PhaseStepper } from './PhaseStepper';
+
+test('marks the active stage and not the others', () => {
+  const { container } = render(<PhaseStepper stage="attackers" />);
+  const q = within(container);
+  expect(q.getByText('Attackers').className).toMatch(/on/);
+  expect(q.getByText('Defenders').className).not.toMatch(/on/);
+  expect(q.getByText('Refusal').className).not.toMatch(/on/);
+});

--- a/web/src/components/PhaseStepper.tsx
+++ b/web/src/components/PhaseStepper.tsx
@@ -1,0 +1,23 @@
+interface PhaseStepperProps {
+  stage: 'defender' | 'attackers' | 'refusal';
+}
+
+const STEPS = [
+  { key: 'defender', label: 'Defenders' },
+  { key: 'attackers', label: 'Attackers' },
+  { key: 'refusal', label: 'Refusal' },
+] as const;
+
+/** The round's three steps as a segmented indicator (docs/design-mockup.html
+ * "Trainer": Defenders | Attackers | Refusal). The current stage is `.on`. */
+export function PhaseStepper({ stage }: PhaseStepperProps) {
+  return (
+    <div className="stepper segmented" role="list" aria-label="Draft phase">
+      {STEPS.map((step) => (
+        <span key={step.key} role="listitem" aria-current={step.key === stage} className={step.key === stage ? 'on' : ''}>
+          {step.label}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/RemainingMatchups.test.tsx
+++ b/web/src/components/RemainingMatchups.test.tsx
@@ -1,0 +1,19 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { render, within } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { fixtureMatrix, smoke } from '../conformance/fixtures';
+import { initDraft } from '../draft/draftState';
+import { RemainingMatchups } from './RemainingMatchups';
+
+test('summarises the remaining grid size', () => {
+  const matrix = fixtureMatrix(smoke);
+  const model = initDraft(matrix, smoke.neutralWeight);
+  const { container } = render(
+    <RemainingMatchups model={model} myNames={matrix.myNames} enemyNames={matrix.enemyNames} />,
+  );
+  const q = within(container);
+  expect(
+    q.getByText(new RegExp(`${model.myRemaining.length}\\s*[×x]\\s*${model.enemyRemaining.length}`)),
+  ).toBeInTheDocument();
+});

--- a/web/src/components/RemainingMatchups.tsx
+++ b/web/src/components/RemainingMatchups.tsx
@@ -1,0 +1,58 @@
+import type { DraftModel } from '../draft/draftState';
+import { scoreBand, toScore } from '../model/scale';
+
+interface RemainingMatchupsProps {
+  model: DraftModel;
+  myNames: string[];
+  enemyNames: string[];
+}
+
+/** Collapsible view of the shrinking sub-matrix as the draft narrows
+ * (docs/design-mockup.html "Trainer": REMAINING MATCHUPS n×n). Best-map values
+ * on the 0–20 scale, banded. `.band-*` colour classes come from the always-
+ * bundled editor.css. Collapsed by default. */
+export function RemainingMatchups({ model, myNames, enemyNames }: RemainingMatchupsProps) {
+  const { myRemaining, enemyRemaining, matrix } = model;
+
+  return (
+    <details className="remaining">
+      <summary>
+        <span className="section-head">Remaining matchups</span>
+        <span className="remaining-size">
+          {myRemaining.length} × {enemyRemaining.length}
+        </span>
+      </summary>
+      <div className="why-scroll">
+        <table className="why-table">
+          <thead>
+            <tr>
+              <th className="wcorner" />
+              {enemyRemaining.map((e) => (
+                <th key={e}>
+                  <span className="wlabel enemy">{enemyNames[e]}</span>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {myRemaining.map((m) => (
+              <tr key={m}>
+                <th className="wrow">
+                  <span className="wlabel mine">{myNames[m]}</span>
+                </th>
+                {enemyRemaining.map((e) => {
+                  const score = toScore(matrix.cells[m][e].best);
+                  return (
+                    <td key={e} className={`num band-${scoreBand(score)}`}>
+                      {score}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </details>
+  );
+}

--- a/web/src/components/WhyPanel.test.tsx
+++ b/web/src/components/WhyPanel.test.tsx
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { render, within } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { fixtureMatrix, smoke } from '../conformance/fixtures';
+import { DraftEngine } from '../engine/engine';
+import { initDraft } from '../draft/draftState';
+import { WhyPanel } from './WhyPanel';
+
+test('defender stage: shows both the EV-per-choice list and the threat sub-matrix', () => {
+  const matrix = fixtureMatrix(smoke);
+  const model = initDraft(matrix, smoke.neutralWeight);
+  const engine = new DraftEngine(matrix, null, smoke.neutralWeight);
+  engine.solve();
+  const node = engine.nodeResult([]);
+
+  const { container } = render(
+    <WhyPanel node={node} model={model} myNames={matrix.myNames} enemyNames={matrix.enemyNames} />,
+  );
+  const q = within(container);
+
+  expect(q.getByText(/Team EV per defender choice/i)).toBeInTheDocument();
+  expect(q.getByText(/Score vs their biggest threats/i)).toBeInTheDocument();
+  // One EV row per candidate defender.
+  expect(container.querySelectorAll('.ev-table tr').length).toBe(node.choices.length);
+});

--- a/web/src/components/WhyPanel.tsx
+++ b/web/src/components/WhyPanel.tsx
@@ -1,7 +1,7 @@
 import type { NodeResult } from '../engine/types';
 import type { DraftModel } from '../draft/draftState';
 import { topThreats } from '../draft/cards';
-import { scoreBand, teamResult, toScore } from '../model/scale';
+import { formatTeamScore, scoreBand, teamTotal, toScore } from '../model/scale';
 
 interface WhyPanelProps {
   node: NodeResult;
@@ -26,7 +26,7 @@ export function WhyPanel({ node, model, myNames, enemyNames }: WhyPanelProps) {
   // choice's sub-game value (best continuation), converted to the 0–20n scale.
   const achieved = model.fixed.reduce((sum, g) => sum + g.value, 0);
   const ranked = node.choices
-    .map((c) => ({ id: c.id, name: joinName(c.name), score: teamResult(achieved + c.ev, model.n).my }))
+    .map((c) => ({ id: c.id, name: joinName(c.name), score: teamTotal(achieved + c.ev, model.n) }))
     .sort((a, b) => b.score - a.score);
   const scores = ranked.map((r) => r.score);
   const maxScore = Math.max(...scores);
@@ -50,7 +50,7 @@ export function WhyPanel({ node, model, myNames, enemyNames }: WhyPanelProps) {
                   <td className="ev-bar">
                     <span className={i === 0 ? 'top' : ''} style={{ width: `${barPct(r.score)}%` }} />
                   </td>
-                  <td className="ev-val num">{r.score}</td>
+                  <td className="ev-val num">{formatTeamScore(r.score)}</td>
                 </tr>
               ))}
             </tbody>

--- a/web/src/components/WhyPanel.tsx
+++ b/web/src/components/WhyPanel.tsx
@@ -1,49 +1,98 @@
 import type { NodeResult } from '../engine/types';
+import type { DraftModel } from '../draft/draftState';
+import { topThreats } from '../draft/cards';
+import { scoreBand, teamResult, toScore } from '../model/scale';
 
-/** The Why panel (§3.3): the payoff matrix at the current node (child game
- * values, internal team-margin scale) with both equilibrium mixes on the
- * margins and the support cells highlighted. */
-export function WhyPanel({ node }: { node: NodeResult }) {
-  const why = node.why;
-  if (!why) return null;
+interface WhyPanelProps {
+  node: NodeResult;
+  model: DraftModel;
+  myNames: string[];
+  enemyNames: string[];
+}
+
+function joinName(name: string | [string, string]): string {
+  return typeof name === 'string' ? name : `${name[0]} + ${name[1]}`;
+}
+
+/** Why the bot plays what it plays (docs/design-mockup.html "WHY THIS PLAY"):
+ * a ranked "team EV per choice" bar list, plus — at the defender stage — a small
+ * "score vs their biggest threats" sub-matrix (our top candidates × the enemy's
+ * top-weighted defenders). Replaces the raw full payoff matrix. */
+export function WhyPanel({ node, model, myNames, enemyNames }: WhyPanelProps) {
+  if (!node.why) return null;
   const unit = node.stage === 'defender' ? 'defender' : node.stage === 'attackers' ? 'attacker pair' : 'refusal';
+
+  // Each choice's projected full-draft team score = already-fixed games + this
+  // choice's sub-game value (best continuation), converted to the 0–20n scale.
+  const achieved = model.fixed.reduce((sum, g) => sum + g.value, 0);
+  const ranked = node.choices
+    .map((c) => ({ id: c.id, name: joinName(c.name), score: teamResult(achieved + c.ev, model.n).my }))
+    .sort((a, b) => b.score - a.score);
+  const scores = ranked.map((r) => r.score);
+  const maxScore = Math.max(...scores);
+  const minScore = Math.min(...scores);
+  const span = maxScore - minScore || 1;
+  const barPct = (score: number): number => 35 + (65 * (score - minScore)) / span;
+
+  const threats = topThreats(model, node, 3);
+  const topRows = ranked.slice(0, 3);
 
   return (
     <div className="why">
-      <div className="section-head">Payoff — team margin per {unit} choice (rows = you, cols = them)</div>
-      <div className="why-scroll">
-        <table className="why-table">
-          <thead>
-            <tr>
-              <th className="wcorner" />
-              {why.colLabels.map((label, j) => (
-                <th key={j}>
-                  <div className="wlabel enemy">{label}</div>
-                  <div className="wprob">{(why.enStrategy[j] * 100).toFixed(0)}%</div>
-                </th>
+      <div className="why-grid">
+        <div className="why-ev">
+          <div className="section-head">Team EV per {unit} choice</div>
+          <table className="ev-table">
+            <tbody>
+              {ranked.map((r, i) => (
+                <tr key={i}>
+                  <td className="ev-name">{r.name}</td>
+                  <td className="ev-bar">
+                    <span className={i === 0 ? 'top' : ''} style={{ width: `${barPct(r.score)}%` }} />
+                  </td>
+                  <td className="ev-val num">{r.score}</td>
+                </tr>
               ))}
-            </tr>
-          </thead>
-          <tbody>
-            {why.rowLabels.map((label, i) => (
-              <tr key={i}>
-                <th className="wrow">
-                  <span className="wlabel mine">{label}</span>
-                  <span className="wprob">{(why.myStrategy[i] * 100).toFixed(0)}%</span>
-                </th>
-                {why.colLabels.map((_, j) => {
-                  const v = why.payoff[i][j];
-                  const support = why.myStrategy[i] > 1e-6 && why.enStrategy[j] > 1e-6;
-                  return (
-                    <td key={j} className={support ? 'wcell support num' : 'wcell num'}>
-                      {v >= 0 ? '+' : ''}{v.toFixed(1)}
-                    </td>
-                  );
-                })}
-              </tr>
-            ))}
-          </tbody>
-        </table>
+            </tbody>
+          </table>
+        </div>
+
+        {node.stage === 'defender' && threats.length > 0 && (
+          <div className="why-threats">
+            <div className="section-head">Score vs their biggest threats</div>
+            <div className="why-scroll">
+              <table className="why-table">
+                <thead>
+                  <tr>
+                    <th className="wcorner" />
+                    {threats.map((t) => (
+                      <th key={t.enemyIndex}>
+                        <span className="wlabel enemy">{enemyNames[t.enemyIndex]}</span>
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {topRows.map((r) => (
+                    <tr key={r.id as number}>
+                      <th className="wrow">
+                        <span className="wlabel mine">{myNames[r.id as number]}</span>
+                      </th>
+                      {threats.map((t) => {
+                        const score = toScore(model.matrix.cells[r.id as number][t.enemyIndex].best);
+                        return (
+                          <td key={t.enemyIndex} className={`num band-${scoreBand(score)}`}>
+                            {score}
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/web/src/components/trainer.css
+++ b/web/src/components/trainer.css
@@ -25,6 +25,28 @@
 .reveal .r-enemy { color: var(--enemy); font-weight: 600; }
 @keyframes wtcFlip { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: none; } }
 
+/* --- draft board (docs/design-mockup.html "Trainer") --- */
+.draft-board { display: flex; gap: 1rem; margin-bottom: 1rem; }
+.board-panel { flex: 1; min-width: 0; background: var(--card); border: 1px solid var(--border); border-radius: var(--radius); padding: 0.9rem 1rem; }
+.board-title { font-size: 0.7rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-4); margin-bottom: 0.6rem; }
+.slot { display: flex; align-items: center; gap: 0.6rem; padding: 0.55rem 0.7rem; border: 1px solid var(--border-strong); border-radius: var(--radius-sm); background: var(--bg-2); }
+.slot .slot-name { font-weight: 600; }
+.slot.def { margin-bottom: 0.5rem; }
+.slot.def .slot-tag { font-family: var(--font-mono); font-size: 0.7rem; font-weight: 700; letter-spacing: 0.06em; padding: 0.1rem 0.35rem; border-radius: 4px; color: #06101c; }
+.slot.mine .slot-tag { background: var(--blue); }
+.slot.enemy .slot-tag { background: var(--enemy); }
+.slot.mine.filled .slot-name { color: var(--blue); }
+.slot.enemy.filled .slot-name { color: var(--enemy); }
+.slot.pending .slot-name, .slot.hidden .slot-name, .slot.empty .slot-name { color: var(--text-4); font-weight: 500; }
+.slot.hidden, .slot.empty { border-style: dashed; }
+.slot.atk.enemy.hidden { border-color: #e0573e55; }
+.slot.active { border-color: var(--blue); box-shadow: 0 0 0 1px var(--blue) inset; }
+.slot-pair { display: flex; gap: 0.4rem; }
+.slot-pair .slot { flex: 1; justify-content: center; }
+.board-hint { margin-top: 0.4rem; color: var(--text-4); font-size: 0.78rem; }
+
+@media (max-width: 640px) { .draft-board { flex-direction: column; } }
+
 .choices { display: flex; flex-direction: column; gap: 0.4rem; }
 .choice {
   display: flex; align-items: center; gap: 0.75rem; width: 100%; text-align: left;

--- a/web/src/components/trainer.css
+++ b/web/src/components/trainer.css
@@ -79,6 +79,18 @@
 .wcell { color: var(--text-3); }
 .wcell.support { color: var(--text); background: #4e9af114; font-weight: 600; }
 
+/* remaining-matchups collapsible */
+.remaining { margin-top: 1.25rem; }
+.remaining > summary { list-style: none; cursor: pointer; display: flex; align-items: center; gap: 0.5rem;
+  padding: 0.6rem 0.9rem; background: var(--card); border: 1px solid var(--border); border-radius: var(--radius); }
+.remaining > summary::-webkit-details-marker { display: none; }
+.remaining > summary .section-head { margin-bottom: 0; }
+.remaining > summary::after { content: '▾'; margin-left: auto; color: var(--text-4); }
+.remaining[open] > summary::after { content: '▴'; }
+.remaining[open] > summary { border-bottom-left-radius: 0; border-bottom-right-radius: 0; }
+.remaining .remaining-size { color: var(--text-3); font-family: var(--font-mono); font-size: 0.85rem; }
+.remaining .why-scroll { border-top-left-radius: 0; border-top-right-radius: 0; }
+
 .locked { margin-top: 1.5rem; }
 .locked-list { display: flex; flex-direction: column; gap: 0.3rem; }
 .pairing {

--- a/web/src/components/trainer.css
+++ b/web/src/components/trainer.css
@@ -68,6 +68,15 @@
 .lock-bar { display: flex; align-items: center; gap: 0.75rem; margin-top: 1rem; }
 
 .why { margin-top: 1.25rem; }
+.why-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; align-items: start; }
+.why-ev .section-head, .why-threats .section-head { margin-bottom: 0.6rem; }
+.ev-table { width: 100%; border-collapse: collapse; }
+.ev-table td { padding: 0.22rem 0.35rem; vertical-align: middle; }
+.ev-name { white-space: nowrap; color: var(--text-1); }
+.ev-bar { width: 100%; }
+.ev-bar > span { display: block; height: 0.5rem; border-radius: 3px; background: var(--text-3); min-width: 2px; }
+.ev-bar > span.top { background: var(--green); }
+.ev-val { text-align: right; color: var(--text-2); width: 3rem; }
 .why-scroll { overflow-x: auto; border: 1px solid var(--border); border-radius: var(--radius); }
 .why-table { border-collapse: collapse; width: 100%; font-size: 0.85rem; }
 .why-table th, .why-table td { border: 1px solid var(--border); padding: 0.35rem 0.5rem; text-align: center; }
@@ -75,9 +84,6 @@
 .why-table .wrow { text-align: left; white-space: nowrap; background: var(--bg-2); }
 .wlabel.mine { color: var(--blue); }
 .wlabel.enemy { color: var(--enemy); }
-.wprob { color: var(--text-4); font-family: var(--font-mono); font-size: 0.78rem; }
-.wcell { color: var(--text-3); }
-.wcell.support { color: var(--text); background: #4e9af114; font-weight: 600; }
 
 /* remaining-matchups collapsible */
 .remaining { margin-top: 1.25rem; }

--- a/web/src/components/trainer.css
+++ b/web/src/components/trainer.css
@@ -4,6 +4,10 @@
 .trainer-head { display: flex; align-items: baseline; gap: 0.75rem; flex-wrap: wrap; margin-bottom: 0.25rem; }
 .trainer-head h2 { font-size: 1.25rem; }
 .round-badge { color: var(--text-3); font-family: var(--font-mono); }
+.trainer-head .projected { color: var(--text-3); font-size: 0.85rem; font-family: var(--font-mono); }
+.trainer-head .projected .pnum { color: var(--text-1); font-weight: 700; }
+.trainer-head .projected .pdelta.up { color: var(--green); }
+.trainer-head .projected .pdelta.down { color: var(--amber); }
 .trainer-sub { color: var(--text-3); margin-bottom: 1rem; }
 
 .trainer-controls { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; margin-bottom: 1rem; }
@@ -52,18 +56,20 @@
 
 @media (max-width: 640px) { .draft-board { flex-direction: column; } }
 
-.choices { display: flex; flex-direction: column; gap: 0.4rem; }
+.choices.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(13rem, 1fr)); gap: 0.5rem; }
 .choice {
-  display: flex; align-items: center; gap: 0.75rem; width: 100%; text-align: left;
-  padding: 0.6rem 0.9rem; background: var(--card); border: 1px solid var(--border-strong); border-radius: var(--radius-sm);
+  display: flex; flex-direction: column; align-items: flex-start; gap: 0.3rem; width: 100%; text-align: left;
+  padding: 0.7rem 0.9rem; background: var(--card); border: 1px solid var(--border-strong); border-radius: var(--radius-sm);
 }
 .choice:hover:not(:disabled) { border-color: var(--blue); }
 .choice.selected { border-color: var(--blue); background: var(--card-2); }
-.choice .cname { flex: 1; font-weight: 600; }
-.choice .cprob { color: var(--text-2); font-family: var(--font-mono); width: 3.5rem; text-align: right; }
-.choice .cbar { width: 6rem; height: 0.4rem; background: var(--bg-2); border-radius: 3px; overflow: hidden; }
+.choice .cname { font-weight: 600; }
+.choice .cstat { color: var(--text-3); font-size: 0.8rem; }
+.choice .chint { display: flex; align-items: center; gap: 0.5rem; width: 100%; margin-top: 0.15rem; }
+.choice .cbar { flex: 1; height: 0.4rem; background: var(--bg-2); border-radius: 3px; overflow: hidden; }
 .choice .cbar > span { display: block; height: 100%; background: var(--blue); }
-.choice .cev { color: var(--text-3); font-family: var(--font-mono); width: 4rem; text-align: right; }
+.choice .cprob { color: var(--text-2); font-family: var(--font-mono); font-size: 0.82rem; }
+.choice .cev { color: var(--text-3); font-family: var(--font-mono); font-size: 0.82rem; }
 
 .lock-bar { display: flex; align-items: center; gap: 0.75rem; margin-top: 1rem; }
 
@@ -103,6 +109,7 @@
   display: flex; align-items: center; gap: 0.6rem; padding: 0.4rem 0.7rem;
   background: var(--card); border: 1px solid var(--border); border-radius: var(--radius-sm); font-size: 0.9rem;
 }
+.placeholder-pairing { color: var(--text-4); border-style: dashed; }
 .pairing .pmine { color: var(--blue); font-weight: 600; }
 .pairing .penemy { color: var(--enemy); font-weight: 600; }
 .pairing .pkind { color: var(--text-4); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.04em; margin-left: auto; }

--- a/web/src/components/trainer.css
+++ b/web/src/components/trainer.css
@@ -25,6 +25,11 @@
 .reveal .r-enemy { color: var(--enemy); font-weight: 600; }
 @keyframes wtcFlip { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: none; } }
 
+/* phase stepper (Defenders | Attackers | Refusal) */
+.stepper { margin-bottom: 0.75rem; }
+.stepper span { padding: 0.35rem 0.8rem; border-radius: 6px; color: var(--text-4); font-size: 0.85rem; }
+.stepper span.on { background: var(--blue); color: #06101c; font-weight: 600; }
+
 /* --- draft board (docs/design-mockup.html "Trainer") --- */
 .draft-board { display: flex; gap: 1rem; margin-bottom: 1rem; }
 .board-panel { flex: 1; min-width: 0; background: var(--card); border: 1px solid var(--border); border-radius: var(--radius); padding: 0.9rem 1rem; }

--- a/web/src/draft/cards.test.ts
+++ b/web/src/draft/cards.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'vitest';
+import { fixtureMatrix, smoke } from '../conformance/fixtures';
+import { DraftEngine } from '../engine/engine';
+import { initDraft } from './draftState';
+import { candidateStats, projectedResult, topThreats } from './cards';
+
+describe('candidateStats', () => {
+  test('defender stage: avg + floor of my row over enemy remaining (best map)', () => {
+    const matrix = fixtureMatrix(smoke);
+    const model = initDraft(matrix, smoke.neutralWeight);
+    const engine = new DraftEngine(matrix, null, smoke.neutralWeight);
+    engine.solve();
+    const node = engine.nodeResult([]);
+
+    const s = candidateStats(model, node, 0);
+    const my = node.choices[0].id as number;
+    const vals = model.enemyRemaining.map((e) => matrix.cells[my][e].best + 10); // → 0–20
+    expect(s.floor).toBe(Math.min(...vals));
+    expect(s.avg).toBe(Math.round(vals.reduce((a, b) => a + b, 0) / vals.length));
+  });
+
+  test('attackers stage: worst-map values of the pair vs their defender', () => {
+    const matrix = fixtureMatrix(smoke);
+    const engine = new DraftEngine(matrix, null, smoke.neutralWeight);
+    engine.solve();
+
+    let model = initDraft(matrix, smoke.neutralWeight);
+    const root = engine.nodeResult([]);
+    // Lock a defender move to reach the attackers node.
+    const myDef = root.choices[0].id as number;
+    const enDef = model.enemyRemaining[0];
+    model = {
+      ...model,
+      myDefender: myDef,
+      enemyDefender: enDef,
+      path: [{ stage: 'defender', my: myDef, enemy: enDef }],
+    };
+    const node = engine.nodeResult(model.path);
+
+    const s = candidateStats(model, node, 0);
+    const [a, b] = node.choices[0].id as [number, number];
+    const vals = [matrix.cells[a][enDef].worst + 10, matrix.cells[b][enDef].worst + 10];
+    expect(s.floor).toBe(Math.min(...vals));
+    expect(s.avg).toBe(Math.round((vals[0] + vals[1]) / 2));
+  });
+});
+
+describe('projectedResult', () => {
+  test('at the root, projected equals expected (delta ~0)', () => {
+    const matrix = fixtureMatrix(smoke);
+    const model = initDraft(matrix, smoke.neutralWeight);
+    const engine = new DraftEngine(matrix, null, smoke.neutralWeight);
+    const expected = engine.solve();
+    const node = engine.nodeResult([]);
+
+    const { projected, delta } = projectedResult(model, node, expected);
+    // At the root nothing is fixed yet, so projected = best continuation ev.
+    // The best pure response against the equilibrium mix equals the game value.
+    expect(projected).toBeCloseTo(expected, 6);
+    expect(delta).toBeCloseTo(0, 6);
+  });
+});
+
+describe('topThreats', () => {
+  test('defender stage: top-k enemy remaining by equilibrium weight, descending', () => {
+    const matrix = fixtureMatrix(smoke);
+    const model = initDraft(matrix, smoke.neutralWeight);
+    const engine = new DraftEngine(matrix, null, smoke.neutralWeight);
+    engine.solve();
+    const node = engine.nodeResult([]);
+
+    const threats = topThreats(model, node, 2);
+    expect(threats.length).toBeLessThanOrEqual(2);
+    const weights = threats.map((t) => t.weight);
+    expect([...weights].sort((a, b) => b - a)).toEqual(weights); // already descending
+    expect(model.enemyRemaining).toContain(threats[0].enemyIndex);
+  });
+
+  test('non-defender stages return no threats', () => {
+    const matrix = fixtureMatrix(smoke);
+    const engine = new DraftEngine(matrix, null, smoke.neutralWeight);
+    engine.solve();
+    let model = initDraft(matrix, smoke.neutralWeight);
+    const root = engine.nodeResult([]);
+    const myDef = root.choices[0].id as number;
+    const enDef = model.enemyRemaining[0];
+    model = { ...model, myDefender: myDef, enemyDefender: enDef, path: [{ stage: 'defender', my: myDef, enemy: enDef }] };
+    const node = engine.nodeResult(model.path);
+    expect(topThreats(model, node)).toEqual([]);
+  });
+});

--- a/web/src/draft/cards.ts
+++ b/web/src/draft/cards.ts
@@ -1,0 +1,78 @@
+import type { NodeResult } from '../engine/types';
+import type { DraftModel } from './draftState';
+import { toScore } from '../model/scale';
+
+export interface CandidateStats {
+  /** Mean expected score (0–20), rounded. */
+  avg: number;
+  /** Worst-case (minimum) expected score (0–20). */
+  floor: number;
+}
+
+const mean = (xs: number[]): number => Math.round(xs.reduce((a, b) => a + b, 0) / xs.length);
+
+/** Decision-support stats for one choice card, on the 0–20 score scale.
+ * - defender: my row over the enemy remaining pool, best map (I pick the map).
+ * - attackers: the two attackers' worst-map values vs their defender (they defend
+ *   the game my attackers play into).
+ * - refusal: the kept matchup (my defender vs the enemy attacker I keep), best
+ *   map. There is a single value here, so avg === floor. */
+export function candidateStats(model: DraftModel, node: NodeResult, choiceIndex: number): CandidateStats {
+  const choice = node.choices[choiceIndex];
+  const cells = model.matrix.cells;
+
+  if (node.stage === 'defender') {
+    const my = choice.id as number;
+    const vals = model.enemyRemaining.map((e) => toScore(cells[my][e].best));
+    return { avg: mean(vals), floor: Math.min(...vals) };
+  }
+
+  if (node.stage === 'attackers') {
+    const [a, b] = choice.id as [number, number];
+    const d = model.enemyDefender;
+    const vals = [toScore(cells[a][d].worst), toScore(cells[b][d].worst)];
+    return { avg: mean(vals), floor: Math.min(...vals) };
+  }
+
+  // refusal: choice.id = the enemy attacker I refuse; my defender keeps the other.
+  const refuse = choice.id as number;
+  const [ea, eb] = model.enemyPair!;
+  const kept = ea === refuse ? eb : ea;
+  const v = toScore(cells[model.myDefender][kept].best);
+  return { avg: v, floor: v };
+}
+
+/** Team margin (internal scale) if you play the best continuation from `node`,
+ * plus how that compares to the solver's pre-draft equilibrium value. `expected`
+ * is the root game value. At the root the best pure response equals the game
+ * value, so delta is ~0; as the enemy's sampled reveals diverge from
+ * equilibrium, delta tracks how far ahead/behind plan the realised draft is. */
+export function projectedResult(
+  model: DraftModel,
+  node: NodeResult,
+  expected: number,
+): { projected: number; delta: number } {
+  const achieved = model.fixed.reduce((sum, g) => sum + g.value, 0);
+  const bestEv = node.choices.reduce((m, c) => Math.max(m, c.ev), -Infinity);
+  const projected = achieved + bestEv;
+  return { projected, delta: projected - expected };
+}
+
+export interface Threat {
+  enemyIndex: number;
+  label: string;
+  weight: number;
+}
+
+/** The enemy's biggest threats at the defender stage: their equilibrium defender
+ * mix (`node.why.enStrategy`) ranked descending, top-k. At this stage
+ * `colLabels[j]` maps 1:1 to `model.enemyRemaining[j]`. Empty for non-defender
+ * stages — the threat sub-matrix is defender-specific. */
+export function topThreats(model: DraftModel, node: NodeResult, k = 3): Threat[] {
+  if (node.stage !== 'defender' || !node.why) return [];
+  const why = node.why;
+  return why.colLabels
+    .map((label, j) => ({ enemyIndex: model.enemyRemaining[j], label, weight: why.enStrategy[j] }))
+    .sort((a, b) => b.weight - a.weight)
+    .slice(0, k);
+}

--- a/web/src/model/scale.test.ts
+++ b/web/src/model/scale.test.ts
@@ -90,12 +90,11 @@ describe('teamTotal / formatTeamScore', () => {
     expect(Math.round(teamTotal(6.19, 8))).toBe(teamResult(6.19, 8).my);
   });
 
-  test('formatTeamScore shows one decimal, dropping a trailing .0', () => {
+  test('formatTeamScore always shows one decimal', () => {
     expect(formatTeamScore(86.1)).toBe('86.1');
-    expect(formatTeamScore(86)).toBe('86');
-    expect(formatTeamScore(45.0)).toBe('45');
-    expect(formatTeamScore(80.04)).toBe('80'); // rounds to one decimal
-    expect(formatTeamScore(80.05)).toBe('80.1');
+    expect(formatTeamScore(86)).toBe('86.0');
+    expect(formatTeamScore(45)).toBe('45.0');
+    expect(formatTeamScore(44.94)).toBe('44.9'); // rounds to one decimal
   });
 });
 

--- a/web/src/model/scale.test.ts
+++ b/web/src/model/scale.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { formatCell, parseRating, scoreBand, teamResult, toInputString, toScore } from './scale';
+import { formatCell, formatTeamScore, parseRating, scoreBand, teamResult, teamTotal, toInputString, toScore } from './scale';
 
 describe('parseRating', () => {
   test('legacy tokens map to internal deviations from an even game', () => {
@@ -78,6 +78,24 @@ describe('teamResult', () => {
     expect(r.enemy).toBe(74);
     expect(r.my + r.enemy).toBe(160);
     expect(r.favored).toBe(6);
+  });
+});
+
+describe('teamTotal / formatTeamScore', () => {
+  test('teamTotal is the unrounded my-total at the 10n baseline', () => {
+    expect(teamTotal(6.1, 8)).toBeCloseTo(86.1, 6);
+    expect(teamTotal(0, 8)).toBe(80);
+    expect(teamTotal(5, 4)).toBe(45);
+    // matches teamResult.my once rounded
+    expect(Math.round(teamTotal(6.19, 8))).toBe(teamResult(6.19, 8).my);
+  });
+
+  test('formatTeamScore shows one decimal, dropping a trailing .0', () => {
+    expect(formatTeamScore(86.1)).toBe('86.1');
+    expect(formatTeamScore(86)).toBe('86');
+    expect(formatTeamScore(45.0)).toBe('45');
+    expect(formatTeamScore(80.04)).toBe('80'); // rounds to one decimal
+    expect(formatTeamScore(80.05)).toBe('80.1');
   });
 });
 

--- a/web/src/model/scale.ts
+++ b/web/src/model/scale.ts
@@ -62,6 +62,16 @@ export function teamResult(expected: number, n: number): TeamResult {
   return { my, enemy: 2 * even - my, favored: my - even };
 }
 
+/** My team's exact (unrounded) total on the 0–20n scale for an internal margin
+ * — the same baseline teamResult uses, but kept fractional for expected-value
+ * figures (the trainer's per-choice EV and projected score). */
+export const teamTotal = (margin: number, n: number): number => 10 * n + margin;
+
+/** Format a team total for display: one decimal, trailing ".0" dropped
+ * (e.g. 86 or 86.1). Keeps the trainer's EV cards and projected score on the
+ * same scale so they read as the same number. */
+export const formatTeamScore = (total: number): string => (Math.round(total * 10) / 10).toString();
+
 export type ScoreBand = 'worst' | 'bad' | 'okay' | 'good' | 'best';
 
 /** Colour band for a 0-20 score, per the editor legend: worst ≤4, bad 5-8,

--- a/web/src/model/scale.ts
+++ b/web/src/model/scale.ts
@@ -67,10 +67,10 @@ export function teamResult(expected: number, n: number): TeamResult {
  * figures (the trainer's per-choice EV and projected score). */
 export const teamTotal = (margin: number, n: number): number => 10 * n + margin;
 
-/** Format a team total for display: one decimal, trailing ".0" dropped
- * (e.g. 86 or 86.1). Keeps the trainer's EV cards and projected score on the
- * same scale so they read as the same number. */
-export const formatTeamScore = (total: number): string => (Math.round(total * 10) / 10).toString();
+/** Format a team total for display: always one decimal (e.g. 86.0 or 86.1).
+ * Keeps the trainer's EV cards and projected score on the same scale so they
+ * read as the same number. */
+export const formatTeamScore = (total: number): string => total.toFixed(1);
 
 export type ScoreBand = 'worst' | 'bad' | 'okay' | 'good' | 'best';
 

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -9,10 +9,11 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   test: {
-    // globals: true so @testing-library/react auto-registers afterEach(cleanup)
-    // between component tests. The existing suites import from 'vitest'
-    // explicitly and are unaffected.
     globals: true,
     environment: 'node',
+    // RTL's auto-cleanup was not registering reliably under `globals`, leaking
+    // component renders into later tests as duplicate elements. Register an
+    // explicit afterEach(cleanup) via the setup file instead.
+    setupFiles: ['./vitest.setup.ts'],
   },
 });

--- a/web/vitest.setup.ts
+++ b/web/vitest.setup.ts
@@ -1,0 +1,11 @@
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+// Unmount React trees between tests. @testing-library/react's auto-cleanup does
+// not reliably register under our Vitest `globals` config (component renders
+// were leaking into later tests as duplicate elements), so register it
+// explicitly. cleanup() is a no-op in the node-environment engine/conformance
+// suites (nothing is mounted there).
+afterEach(() => {
+  cleanup();
+});


### PR DESCRIPTION
## M5 — Design fidelity, PR2 of 3

Stacked on #48 (fonts). The review found the Trainer had reproduced the draft *mechanics* but dropped almost the entire *presentation layer* the design is built around. This rebuilds it to match `docs/design-mockup.html`. **No engine/worker/solver/fixture changes** — all UI + pure helpers.

### What's added
- **Draft board** — the missing centerpiece: two panels ("OUR DEFENDER · OUR MAP" / "THEIR DEFENDER · THEIR MAP") showing each side's defender flanked by the two opposing attackers, with `selecting…` / `?` / `—` placeholders and an active-slot highlight. Driven entirely from the existing `DraftModel` round scratch.
- **Phase stepper** — `Defenders | Attackers | Refusal`.
- **Choice cards** — replaces the flat list with a card grid; each card shows `our map · avg · floor` (always visible) plus the equilibrium bar / % / EV when hints are on.
- **Projected vs plan** — `Projected N +Δ vs plan` in the round header.
- **WhyPanel redesign** — the raw payoff matrix becomes the design's two-part aid: **TEAM EV PER … CHOICE** (ranked bars) + **SCORE VS THEIR BIGGEST THREATS** (our top candidates × the enemy's top-weighted defenders).
- **Remaining matchups** — collapsible shrinking sub-matrix.
- **Locked pairings** — now shown from round 1 with an `n pairings remaining` placeholder.
- Restores the intro privacy/WTC-lock bullet.

### New pure helpers (unit-tested)
`candidateStats`, `projectedResult`, `topThreats` in `web/src/draft/cards.ts` — all derived from `matrix.cells` + `DraftModel` + `NodeResult`.

### Fixes found along the way
- **Test infra:** RTL's auto-cleanup wasn't registering under our Vitest `globals` config, leaking component renders between tests as duplicate elements (latent; these new tests exposed it). Added an explicit `afterEach(cleanup)` setup file.
- **Trainer bug:** `node` is fetched async, so during an advance/undo the stale node could briefly disagree with the freshly-reset model scratch and crash the new map-stat lookup. Added a model/node re-sync guard.

### Verification
- `npm run typecheck` clean; full `vitest` suite green (99 passed, 2 skipped).
- Verified in-browser against the mockup (board, stepper, cards, projected header, why panel, remaining, locked) with the real IBM Plex fonts.

Next: PR3 (Solver result-card split + stacked mixes, brand/tab polish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)