### PR TITLE
M5 PR3: solver layout + brand/tab polish (P2/P3)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -92,7 +92,7 @@ export function App() {
             title={solvable ? undefined : 'Complete the matrix first'}
             onClick={goSolve}
           >
-            Solver
+            Solve
           </button>
           <button
             className={screen === 'trainer' ? 'tab active' : 'tab'}

--- a/web/src/components/SolveView.tsx
+++ b/web/src/components/SolveView.tsx
@@ -52,15 +52,21 @@ export function SolveView({ myTeam, enemyTeam, n, canRun, solve, onRun, onTrain 
     return (
       <div className="solve done">
         <div className="result-card">
-          <div className="section-head">Expected draft result</div>
-          <div className="big-score">
-            <span className="mine">{score.my}</span>
-            <span className="dash">–</span>
-            <span className="enemy">{score.enemy}</span>
-          </div>
-          <div className="verdict">{verdict}</div>
-          <div className="muted">
-            sum of {n} games · {20 * n} points total
+          <div className="result-split">
+            <div className="result-score">
+              <div className="section-head">Expected draft result</div>
+              <div className="big-score">
+                <span className="mine">{score.my}</span>
+                <span className="dash">–</span>
+                <span className="enemy">{score.enemy}</span>
+              </div>
+            </div>
+            <div className="result-verdict">
+              <div className={`verdict ${score.favored > 0 ? 'up' : score.favored < 0 ? 'down' : ''}`}>{verdict}</div>
+              <div className="muted">
+                sum of {n} games · {20 * n} points total
+              </div>
+            </div>
           </div>
         </div>
 

--- a/web/src/components/solve.css
+++ b/web/src/components/solve.css
@@ -7,8 +7,10 @@
 
 .result-card {
   background: var(--card); border: 1px solid var(--border); border-radius: var(--radius);
-  padding: 1.25rem 1.5rem; text-align: center; margin-bottom: 1.25rem;
+  padding: 1.25rem 1.5rem; margin-bottom: 1.25rem;
 }
+.result-split { display: flex; align-items: center; justify-content: space-between; gap: 1rem; flex-wrap: wrap; }
+.result-verdict { text-align: right; }
 .big-score {
   font-family: var(--font-mono); font-variant-numeric: tabular-nums;
   font-size: 3rem; font-weight: 700; margin: 0.35rem 0;
@@ -17,8 +19,10 @@
 .big-score .enemy { color: var(--enemy); }
 .big-score .dash { color: var(--text-4); margin: 0 0.6rem; }
 .verdict { font-size: 1.05rem; color: var(--text); font-weight: 600; }
+.verdict.up { color: var(--green); }
+.verdict.down { color: var(--enemy); }
 
-.mixes { display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; }
+.mixes { display: flex; flex-direction: column; gap: 1.25rem; }
 .strategy { background: var(--card); border: 1px solid var(--border); border-radius: var(--radius); padding: 0.9rem 1rem; }
 .strategy .section-head { margin-bottom: 0.6rem; }
 .strategy-table { width: 100%; border-collapse: collapse; }
@@ -39,5 +43,3 @@
 .progress-label { margin-top: 0.45rem; color: var(--text-3); font-size: 0.85rem; }
 
 .solve-actions { display: flex; gap: 0.75rem; margin-top: 1.5rem; }
-
-@media (max-width: 640px) { .mixes { grid-template-columns: 1fr; } }

--- a/web/src/theme.css
+++ b/web/src/theme.css
@@ -108,9 +108,10 @@ input:focus, select:focus, textarea:focus { outline: 2px solid var(--blue); outl
   background: var(--bg-2);
   position: sticky; top: 0; z-index: 10;
 }
-.brand { display: flex; align-items: baseline; gap: 0.5rem; }
-.brand-mark { color: var(--blue); font-weight: 700; letter-spacing: 0.04em; }
-.brand-name { color: var(--text); font-weight: 600; }
+.brand { display: flex; align-items: baseline; gap: 0.4rem; }
+.brand-mark { color: var(--blue); font-weight: 700; letter-spacing: 0.06em; }
+/* one uppercase, letter-spaced wordmark: "WTC DRAFT TRAINER" (design mockup) */
+.brand-name { color: var(--text); font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; }
 
 nav.screens { display: flex; gap: 0.25rem; flex-wrap: wrap; }
 .tab { background: transparent; border-color: transparent; color: var(--text-3); padding: 0.35rem 0.7rem; }


### PR DESCRIPTION
## M5 — Design fidelity, PR3 of 3

Stacked on #49. The final polish slice — Solver layout and brand/tab details from the review. **No engine/worker/solver/fixture changes.**

### Changes
- **Solver result card** → the design's horizontal split: big score on the left, "… favored by N" + "sum of n games · 20n total" on the right (verdict coloured green/red by who's favoured), replacing the fully-centered stack.
- **Strategy mixes** → full-width **stacked** cards with long bars, replacing the cramped 2-column grid.
- **Brand** → one uppercase, letter-spaced `WTC DRAFT TRAINER` wordmark (WTC keeps the blue accent).
- **Tab label** → `Solve` (the internal screen key stays `'solve'`).

### Verification
- `npm run typecheck` clean; full `vitest` suite green (99 passed, 2 skipped).
- Verified in-browser against the mockup: result split, stacked mixes, wordmark, and Solve tab all match.

Completes the M5 design-fidelity milestone (#48 fonts → #49 trainer → this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)