### PR TITLE
Nav tab: Solve → Solver (noun consistency)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -92,7 +92,7 @@ export function App() {
             title={solvable ? undefined : 'Complete the matrix first'}
             onClick={goSolve}
           >
-            Solve
+            Solver
           </button>
           <button
             className={screen === 'trainer' ? 'tab active' : 'tab'}


### PR DESCRIPTION
Post-M5 review fix.

The tabs read **Matrix · Solve · Trainer** — "Solve" is a verb between two nouns and doesn't parallel "Trainer". Rename the tab to **Solver** so the nav is all nouns and Solver/Trainer are parallel.

(This intentionally departs from the design mockup, which used "Solve" — the grammatical consistency wins here.)

One-word change to the nav button text in `App.tsx`; no logic change. Typecheck clean, full suite green (103).

🤖 Generated with [Claude Code](https://claude.com/claude-code)