### PR TITLE
UI/UX fixes for the web draft trainer

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,15 +1,79 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { App } from './App';
+import { fixtureMatrix, smoke } from './conformance/fixtures';
+import { DraftEngine } from './engine/engine';
+import type { Move } from './engine/types';
+import type { SolveState } from './worker/useSolve';
+
+/** A done SolveState backed by a real Smoke engine (so node() returns genuine
+ * decisions) with a spy reset() — lets an App test drive a live draft without a
+ * worker and assert on solver resets. */
+function doneSolve(): SolveState {
+  const engine = new DraftEngine(fixtureMatrix(smoke), null, smoke.neutralWeight);
+  const expected = engine.solve();
+  return {
+    status: 'done',
+    progress: 1,
+    phase: null,
+    result: { type: 'solved', reqId: 1, expected, root: engine.nodeResult([]) },
+    error: null,
+    solvedK: null,
+    solve: vi.fn(),
+    reset: vi.fn(),
+    node: (path: Move[]) => Promise.resolve(engine.nodeResult(path)),
+  };
+}
 
 describe('App', () => {
   test('renders the editor shell with the Local-only pill', () => {
     render(<App />);
     expect(screen.getByText(/Local-only/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Matrix' })).toBeInTheDocument();
+  });
+
+  test('keeps the draft trainer mounted when switching tabs (no reset)', async () => {
+    localStorage.clear();
+    const user = userEvent.setup();
+    const { container } = render(<App />);
+
+    // A valid matrix is needed to reach the Trainer; load a sample.
+    await user.selectOptions(screen.getByLabelText(/Load a sample opponent/i), 'four');
+    await user.click(screen.getByRole('button', { name: 'Trainer' }));
+    expect(container.querySelector('.trainer')).toBeTruthy();
+
+    // Switching to another tab must NOT unmount the trainer (that would reset
+    // any in-progress draft) — it stays in the DOM, just hidden.
+    await user.click(screen.getByRole('button', { name: 'Matrix' }));
+    expect(container.querySelector('.trainer')).toBeTruthy();
+  });
+
+  test('discarding an in-progress draft resets the solver and unlocks the editor', async () => {
+    localStorage.clear();
+    const user = userEvent.setup();
+    const solve = doneSolve();
+    render(<App solve={solve} />);
+
+    // Load a valid matrix and start a draft so the Matrix tab locks.
+    await user.selectOptions(screen.getByLabelText(/Load a sample opponent/i), 'four');
+    await user.click(screen.getByRole('button', { name: 'Trainer' }));
+    await user.click(await screen.findByRole('button', { name: /Start practice draft/ }));
+    await waitFor(() => expect(document.querySelector('.choice')).toBeTruthy());
+
+    await user.click(screen.getByRole('button', { name: 'Matrix' }));
+    expect(screen.getByText(/practice draft is in progress/i)).toBeInTheDocument();
+
+    // Isolate the discard's own reset from the matrix-change effect's resets
+    // (which fire on load because the injected solve starts already-done).
+    vi.mocked(solve.reset).mockClear();
+
+    // "Discard draft to edit" clears both the draft and the solver result.
+    await user.click(screen.getByRole('button', { name: /discard draft to edit/i }));
+    expect(solve.reset).toHaveBeenCalled();
+    expect(screen.queryByText(/practice draft is in progress/i)).not.toBeInTheDocument();
   });
 
   test('the Local-only pill opens (and closes) the privacy explainer', async () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -58,13 +58,9 @@ export function App() {
     });
 
   const goSolve = () => setScreen('solve');
-  const startTraining = () => {
-    if (!solvable) return;
-    // The trainer runs on the exact equilibrium; re-solve if the current
-    // result is a k-preview (or missing).
-    if (!(solve.status === 'done' && solve.solvedK === null)) solve.solve(matrix, null);
-    setScreen('trainer');
-  };
+  // The Trainer tab just navigates; DraftTrainer's "Start practice draft"
+  // triggers the exact solve on demand, so opening the tab no longer solves.
+  const goTrainer = () => setScreen('trainer');
 
   return (
     <div className={settings.cb ? 'app cb' : 'app'}>
@@ -96,7 +92,7 @@ export function App() {
             className={screen === 'trainer' ? 'tab active' : 'tab'}
             disabled={!solvable}
             title={solvable ? undefined : 'Complete the matrix first'}
-            onClick={startTraining}
+            onClick={goTrainer}
           >
             Trainer
           </button>
@@ -140,7 +136,7 @@ export function App() {
             canRun={solvable}
             solve={solve}
             onRun={() => solve.solve(matrix, null)}
-            onTrain={solvable ? startTraining : undefined}
+            onTrain={solvable ? goTrainer : undefined}
           />
         )}
         {screen === 'trainer' && engineMatrix && (
@@ -150,6 +146,7 @@ export function App() {
             enemyTeam={matrix.enemyTeam}
             neutralWeight={NEUTRAL_WEIGHT}
             solve={solve}
+            onSolve={() => solve.solve(matrix, null)}
             onEditMatrix={() => setScreen('editor')}
           />
         )}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -164,7 +164,11 @@ export function App({ solve: injectedSolve }: AppProps = {}) {
           />
         )}
         {/* The trainer stays mounted for the whole session (only hidden when
-            off-tab), so switching tabs never resets an in-progress draft. */}
+            off-tab), so switching tabs never resets an in-progress draft.
+            Invariant: while a draft is live the editor is locked, so
+            `state.current` (hence `engineMatrix`) can't change out from under
+            it — this guard never unmounts DraftTrainer mid-draft, so there's no
+            path that strands `draftLive` true with the trainer gone. */}
         {engineMatrix && (
           <div style={{ display: screen === 'trainer' ? 'contents' : 'none' }}>
             <DraftTrainer

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,7 +3,6 @@ import { AboutModal } from './components/AboutModal';
 import { DraftTrainer } from './components/DraftTrainer';
 import { MatrixEditor } from './components/MatrixEditor';
 import { SolveView } from './components/SolveView';
-import type { BotStyle } from './draft/sampling';
 import { blank, toEngineMatrix } from './model/matrix';
 import type { EditorMatrix } from './model/matrix';
 import { loadState, saveState } from './model/storage';
@@ -20,7 +19,6 @@ const NEUTRAL_WEIGHT = 0.5;
 export function App() {
   const [state, setState] = useState<AppState>(() => loadState());
   const [screen, setScreen] = useState<Screen>('editor');
-  const [botStyle, setBotStyle] = useState<BotStyle>('equilibrium');
   const [showAbout, setShowAbout] = useState(false);
   const solve = useSolve();
 
@@ -152,8 +150,6 @@ export function App() {
             enemyTeam={matrix.enemyTeam}
             neutralWeight={NEUTRAL_WEIGHT}
             solve={solve}
-            botStyle={botStyle}
-            onBotStyleChange={setBotStyle}
             onEditMatrix={() => setScreen('editor')}
           />
         )}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,6 +9,7 @@ import { loadState, saveState } from './model/storage';
 import type { AppState, Settings } from './model/storage';
 import { validateMatrix } from './model/validation';
 import { useSolve } from './worker/useSolve';
+import type { SolveState } from './worker/useSolve';
 
 type Screen = 'editor' | 'solve' | 'trainer';
 
@@ -16,11 +17,24 @@ type Screen = 'editor' | 'solve' | 'trainer';
 // pairing values must use the same to match the engine's totals.
 const NEUTRAL_WEIGHT = 0.5;
 
-export function App() {
+interface AppProps {
+  /** Injectable solver state for tests (a real worker is awkward in jsdom);
+   * production leaves it undefined and uses the app's own useSolve(). */
+  solve?: SolveState;
+}
+
+export function App({ solve: injectedSolve }: AppProps = {}) {
   const [state, setState] = useState<AppState>(() => loadState());
   const [screen, setScreen] = useState<Screen>('editor');
   const [showAbout, setShowAbout] = useState(false);
-  const solve = useSolve();
+  // A practice draft is under way (reported by DraftTrainer). While it is, the
+  // Matrix editor locks so its numbers can't drift out from under the draft.
+  const [draftLive, setDraftLive] = useState(false);
+  // Bumping this remounts DraftTrainer, resetting it to the intro — how "Discard
+  // draft to edit" and a fresh replay clear an in-progress draft.
+  const [draftKey, setDraftKey] = useState(0);
+  const ownSolve = useSolve();
+  const solve = injectedSolve ?? ownSolve;
 
   // Persist the whole blob whenever it changes (§4.2 auto-save).
   useEffect(() => saveState(state), [state]);
@@ -61,6 +75,14 @@ export function App() {
   // The Trainer tab just navigates; DraftTrainer's "Start practice draft"
   // triggers the exact solve on demand, so opening the tab no longer solves.
   const goTrainer = () => setScreen('trainer');
+  // Discard the in-progress draft immediately — no confirm, a draft is quick to
+  // remake. The remount clears the live flag (unlocking the editor); the solve
+  // is cleared too, since discarding to edit means the numbers are about to
+  // change out from under it.
+  const discardDraft = () => {
+    solve.reset();
+    setDraftKey((k) => k + 1);
+  };
 
   return (
     <div className={settings.cb ? 'app cb' : 'app'}>
@@ -126,6 +148,8 @@ export function App() {
             onLoadSave={loadSave}
             onDeleteSave={deleteSave}
             onSolve={solvable ? goSolve : undefined}
+            locked={draftLive}
+            onDiscardDraft={discardDraft}
           />
         )}
         {screen === 'solve' && (
@@ -139,16 +163,22 @@ export function App() {
             onTrain={solvable ? goTrainer : undefined}
           />
         )}
-        {screen === 'trainer' && engineMatrix && (
-          <DraftTrainer
-            matrix={engineMatrix}
-            myTeam={matrix.myTeam}
-            enemyTeam={matrix.enemyTeam}
-            neutralWeight={NEUTRAL_WEIGHT}
-            solve={solve}
-            onSolve={() => solve.solve(matrix, null)}
-            onEditMatrix={() => setScreen('editor')}
-          />
+        {/* The trainer stays mounted for the whole session (only hidden when
+            off-tab), so switching tabs never resets an in-progress draft. */}
+        {engineMatrix && (
+          <div style={{ display: screen === 'trainer' ? 'contents' : 'none' }}>
+            <DraftTrainer
+              key={draftKey}
+              matrix={engineMatrix}
+              myTeam={matrix.myTeam}
+              enemyTeam={matrix.enemyTeam}
+              neutralWeight={NEUTRAL_WEIGHT}
+              solve={solve}
+              onSolve={() => solve.solve(matrix, null)}
+              onEditMatrix={() => setScreen('editor')}
+              onLiveChange={setDraftLive}
+            />
+          </div>
         )}
       </main>
 

--- a/web/src/components/DraftBoard.test.tsx
+++ b/web/src/components/DraftBoard.test.tsx
@@ -11,7 +11,7 @@ describe('DraftBoard', () => {
     const matrix = fixtureMatrix(smoke);
     const model = initDraft(matrix, smoke.neutralWeight);
     const { container } = render(
-      <DraftBoard model={model} myNames={matrix.myNames} enemyNames={matrix.enemyNames} stage="defender" />,
+      <DraftBoard model={model} myNames={matrix.myNames} enemyNames={matrix.enemyNames} />,
     );
     const q = within(container);
 
@@ -33,7 +33,7 @@ describe('DraftBoard', () => {
       enemyPair: [1, 2] as [number, number],
     };
     const { container } = render(
-      <DraftBoard model={model} myNames={matrix.myNames} enemyNames={matrix.enemyNames} stage="refusal" />,
+      <DraftBoard model={model} myNames={matrix.myNames} enemyNames={matrix.enemyNames} />,
     );
     const q = within(container);
 

--- a/web/src/components/DraftBoard.tsx
+++ b/web/src/components/DraftBoard.tsx
@@ -33,7 +33,7 @@ const NO_PENDING: PendingPicks = { defender: null, attackers: [], face: null };
 export function DraftBoard({ model, myNames, enemyNames, pending = NO_PENDING }: DraftBoardProps) {
   // Our defender: locked → pending pick (highlighted) → "selecting…".
   const myDefIdx = model.myDefender >= 0 ? model.myDefender : pending.defender;
-  const myDefCls = myDefIdx != null ? 'slot def mine filled on' : 'slot def mine pending on';
+  const myDefCls = myDefIdx != null ? 'slot def mine filled on' : 'slot def mine pending';
 
   const enDefName = model.enemyDefender >= 0 ? enemyNames[model.enemyDefender] : null;
 

--- a/web/src/components/DraftBoard.tsx
+++ b/web/src/components/DraftBoard.tsx
@@ -59,6 +59,34 @@ export function DraftBoard({ model, myNames, enemyNames, pending = NO_PENDING }:
           : { name: null, cls: 'slot atk mine empty' };
       });
 
+  // Final round only: preview the two games that resolve automatically on lock
+  // — the last players (my leftover player vs theirs) and the refused pair —
+  // filling in as each side becomes known. Shown from the attackers step on.
+  const stage = model.myDefender < 0 ? 'defender' : model.myPair === null ? 'attackers' : 'refusal';
+  const showAutoPaired = model.round === model.finalRound && stage !== 'defender';
+  let myLast = '?';
+  let enLast = '?';
+  let refThem = '?';
+  if (showAutoPaired) {
+    const { myRemaining, enemyRemaining, myDefender, enemyDefender, myPair, enemyPair } = model;
+    if (myPair && enemyPair) {
+      // refusal stage: both leftover players are settled (attackers are locked)
+      const ml = myRemaining.find((x) => x !== myDefender && !myPair.includes(x));
+      if (ml != null) myLast = myNames[ml];
+      const el = enemyRemaining.find((x) => x !== enemyDefender && !enemyPair.includes(x));
+      if (el != null) enLast = enemyNames[el];
+      // the enemy attacker I refuse is the one I'm not facing
+      if (pending.face != null) {
+        const rt = enemyPair.find((x) => x !== pending.face);
+        if (rt != null) refThem = enemyNames[rt];
+      }
+    } else if (pending.attackers.length === 2) {
+      // attackers stage: my leftover is whichever of my players I didn't send
+      const ml = myRemaining.find((x) => x !== myDefender && !pending.attackers.includes(x));
+      if (ml != null) myLast = myNames[ml];
+    }
+  }
+
   return (
     <div className="draft-board">
       <div className="board-panel">
@@ -94,6 +122,20 @@ export function DraftBoard({ model, myNames, enemyNames, pending = NO_PENDING }:
           <div className="board-hint">Your two attackers will land here</div>
         )}
       </div>
+
+      {showAutoPaired && (
+        <div className="board-panel">
+          <div className="board-title">Auto-paired this round</div>
+          <div className="slot def auto">
+            <span className="slot-tag">LAST</span>
+            <span className="slot-name">{myLast} vs {enLast}</span>
+          </div>
+          <div className="slot empty">
+            <span className="slot-name">refused: ? vs {refThem}</span>
+          </div>
+          <div className="board-hint">Resolves on lock · scored as avg of both maps</div>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/DraftBoard.tsx
+++ b/web/src/components/DraftBoard.tsx
@@ -1,57 +1,98 @@
 import type { DraftModel } from '../draft/draftState';
 
+/** In-progress (pre-lock) picks, so the board can fill + highlight the panels as
+ * the user selects — before they lock the choice. */
+export interface PendingPicks {
+  /** Defender stage: my pending defender index, or null before a pick. */
+  defender: number | null;
+  /** Attackers stage: my pending attacker indices, in pick order (≤2). */
+  attackers: number[];
+  /** Pairing stage: the enemy attacker my defender will face (highlighted); the
+   * other member of the sent pair is the refused one (dimmed). Null before a
+   * pick, in which case both are highlighted. */
+  face: number | null;
+}
+
 interface DraftBoardProps {
   model: DraftModel;
   myNames: string[];
   enemyNames: string[];
-  /** The current decision, so the slot being chosen can highlight. */
-  stage: 'defender' | 'attackers' | 'refusal';
+  pending?: PendingPicks;
 }
 
+const NO_PENDING: PendingPicks = { defender: null, attackers: [], face: null };
+
 /** The two-panel draft board (docs/design-mockup.html "Trainer"): each side's
- * defender flanked by the two opposing attackers that land on it. Everything is
- * read from the in-progress round scratch on `DraftModel`; unknown picks show
- * `selecting…` (ours, in progress), `?` (theirs, hidden), or `—` (not sent
- * yet). "our/their map" are conceptual labels — the value model folds the map
- * choice into best/worst rather than naming maps. */
-export function DraftBoard({ model, myNames, enemyNames, stage }: DraftBoardProps) {
-  const myDef = model.myDefender >= 0 ? myNames[model.myDefender] : null;
-  const enDef = model.enemyDefender >= 0 ? enemyNames[model.enemyDefender] : null;
-  const enAtk = model.enemyPair ? (model.enemyPair.map((i) => enemyNames[i]) as [string, string]) : null;
-  const myAtk = model.myPair ? (model.myPair.map((i) => myNames[i]) as [string, string]) : null;
+ * defender flanked by the two opposing attackers that land on it. Reads the
+ * locked round scratch from `DraftModel` and overlays the current in-progress
+ * pick (`pending`) so slots fill and highlight before the user locks — an
+ * in-play slot gets its side's coloured border, a refused attacker stays but
+ * dims, and not-yet-known picks show `selecting…` / `?` / `—`. "our/their map"
+ * are conceptual labels — the value model folds the map choice into best/worst
+ * rather than naming maps. */
+export function DraftBoard({ model, myNames, enemyNames, pending = NO_PENDING }: DraftBoardProps) {
+  // Our defender: locked → pending pick (highlighted) → "selecting…".
+  const myDefIdx = model.myDefender >= 0 ? model.myDefender : pending.defender;
+  const myDefCls = myDefIdx != null ? 'slot def mine filled on' : 'slot def mine pending on';
+
+  const enDefName = model.enemyDefender >= 0 ? enemyNames[model.enemyDefender] : null;
+
+  // Enemy attackers landing on my defender: hidden until the pairing stage, then
+  // the faced one is highlighted and the refused one dimmed.
+  const enAtkSlots: { name: string | null; cls: string }[] = model.enemyPair
+    ? model.enemyPair.map((e) => ({
+        name: enemyNames[e],
+        cls: `slot atk enemy filled ${pending.face == null || e === pending.face ? 'on' : 'muted'}`,
+      }))
+    : [
+        { name: null, cls: 'slot atk enemy hidden' },
+        { name: null, cls: 'slot atk enemy hidden' },
+      ];
+
+  // My attackers landing on their defender: locked pair, else my pending picks.
+  const myAtkSlots: { name: string | null; cls: string }[] = model.myPair
+    ? model.myPair.map((a) => ({ name: myNames[a], cls: 'slot atk mine filled on' }))
+    : [0, 1].map((i) => {
+        const idx = pending.attackers[i];
+        return idx != null
+          ? { name: myNames[idx], cls: 'slot atk mine filled on' }
+          : { name: null, cls: 'slot atk mine empty' };
+      });
 
   return (
     <div className="draft-board">
       <div className="board-panel">
         <div className="board-title">Our defender · our map</div>
-        <div className={`slot def mine${myDef ? ' filled' : ' pending'}${!myDef && stage === 'defender' ? ' active' : ''}`}>
+        <div className={myDefCls}>
           <span className="slot-tag">DEF</span>
-          <span className="slot-name">{myDef ?? 'selecting…'}</span>
+          <span className="slot-name">{myDefIdx != null ? myNames[myDefIdx] : 'selecting…'}</span>
         </div>
         <div className="slot-pair">
-          {(enAtk ?? [null, null]).map((name, i) => (
-            <div key={i} className={`slot atk enemy${name ? ' filled' : ' hidden'}${!enAtk && stage === 'refusal' ? ' active' : ''}`}>
-              <span className="slot-name">{name ?? '?'}</span>
+          {enAtkSlots.map((s, i) => (
+            <div key={i} className={s.cls}>
+              <span className="slot-name">{s.name ?? '?'}</span>
             </div>
           ))}
         </div>
-        {!enAtk && <div className="board-hint">Their two attackers will land here</div>}
+        {!model.enemyPair && <div className="board-hint">Their two attackers will land here</div>}
       </div>
 
       <div className="board-panel">
         <div className="board-title">Their defender · their map</div>
-        <div className={`slot def enemy${enDef ? ' filled' : ' hidden'}`}>
+        <div className={enDefName ? 'slot def enemy filled on' : 'slot def enemy hidden'}>
           <span className="slot-tag">DEF</span>
-          <span className="slot-name">{enDef ?? '?'}</span>
+          <span className="slot-name">{enDefName ?? '?'}</span>
         </div>
         <div className="slot-pair">
-          {(myAtk ?? [null, null]).map((name, i) => (
-            <div key={i} className={`slot atk mine${name ? ' filled' : ' empty'}${!myAtk && stage === 'attackers' ? ' active' : ''}`}>
-              <span className="slot-name">{name ?? '—'}</span>
+          {myAtkSlots.map((s, i) => (
+            <div key={i} className={s.cls}>
+              <span className="slot-name">{s.name ?? '—'}</span>
             </div>
           ))}
         </div>
-        {!myAtk && <div className="board-hint">Your two attackers will land here</div>}
+        {!model.myPair && pending.attackers.length === 0 && (
+          <div className="board-hint">Your two attackers will land here</div>
+        )}
       </div>
     </div>
   );

--- a/web/src/components/DraftSummary.tsx
+++ b/web/src/components/DraftSummary.tsx
@@ -1,5 +1,5 @@
 import { achievedTotal } from '../draft/draftState';
-import type { DraftModel, FixedGame } from '../draft/draftState';
+import type { DraftDecision, DraftModel, FixedGame } from '../draft/draftState';
 import { decompose, verdict } from '../draft/summary';
 import { formatMatchupScore, teamResult, toScore } from '../model/scale';
 import './trainer.css';
@@ -15,11 +15,20 @@ interface DraftSummaryProps {
   onEditMatrix: () => void;
 }
 
+// The defender picks the map, so a played game is on that side's map; the
+// refused / last games have no defender, so they keep their own labels.
 const KIND_LABEL: Record<FixedGame['kind'], string> = {
-  'my-defends': 'you defended',
-  'enemy-defends': 'they defended',
+  'my-defends': 'your map',
+  'enemy-defends': 'their map',
   refused: 'refused pair',
   last: 'last players',
+};
+
+// History row prefix: the phase label + the verb for what you chose.
+const STAGE_HISTORY: Record<DraftDecision['stage'], { label: string; verb: string }> = {
+  defender: { label: 'defenders', verb: 'put up' },
+  attackers: { label: 'attackers', verb: 'sent' },
+  refusal: { label: 'pairing', verb: 'faced' },
 };
 
 function joinName(name: string | [string, string]): string {
@@ -59,19 +68,24 @@ export function DraftSummary({ myTeam, enemyTeam, myNames, enemyNames, expected,
         </div>
       </div>
 
-      {d.leaks.length > 0 && (
-        <div>
-          <div className="section-head">Where you left points (worst first)</div>
-          <div className="leaks-list">
-            {d.leaks.map((leak, i) => (
-              <div className="leak" key={i}>
-                R{leak.round} {leak.stage} — sent {joinName(leak.chosenName)} · best {joinName(leak.bestName)}{' '}
-                <span className="lcost">−{leak.regret.toFixed(1)}</span>
+      <div>
+        <div className="section-head">Your draft</div>
+        <div className="history">
+          {model.decisions.map((dec, i) => {
+            const opt = dec.regret < 0.05;
+            const sh = STAGE_HISTORY[dec.stage];
+            return (
+              <div className="hrow" key={i}>
+                <span className="hlabel">R{dec.round} {sh.label} — {sh.verb} {joinName(dec.chosenName)}</span>
+                <span className="hbest">{opt ? 'best move' : `best ${joinName(dec.bestName)}`}</span>
+                <span className={`hval ${opt ? 'opt' : dec.regret >= 2 ? 'major' : 'minor'}`}>
+                  {opt ? '✓ 0.0' : `−${dec.regret.toFixed(1)}`}
+                </span>
               </div>
-            ))}
-          </div>
+            );
+          })}
         </div>
-      )}
+      </div>
 
       <div className="locked">
         <div className="section-head">Final pairings</div>

--- a/web/src/components/DraftSummary.tsx
+++ b/web/src/components/DraftSummary.tsx
@@ -1,7 +1,7 @@
 import { achievedTotal } from '../draft/draftState';
 import type { DraftModel, FixedGame } from '../draft/draftState';
 import { decompose, verdict } from '../draft/summary';
-import { teamResult, toScore } from '../model/scale';
+import { formatMatchupScore, teamResult, toScore } from '../model/scale';
 import './trainer.css';
 
 interface DraftSummaryProps {
@@ -81,7 +81,7 @@ export function DraftSummary({ myTeam, enemyTeam, myNames, enemyNames, expected,
             return (
               <div className="pairing" key={i}>
                 <span className="pmine">{myNames[game.my]}</span>
-                <span className="pscore">{my.toFixed(1)}–{(20 - my).toFixed(1)}</span>
+                <span className="pscore">{formatMatchupScore(my)}–{formatMatchupScore(20 - my)}</span>
                 <span className="penemy">{enemyNames[game.enemy]}</span>
                 <span className="pkind">{KIND_LABEL[game.kind]}</span>
               </div>

--- a/web/src/components/DraftTrainer.test.tsx
+++ b/web/src/components/DraftTrainer.test.tsx
@@ -37,6 +37,7 @@ describe('DraftTrainer (Smoke 4×4, real engine)', () => {
         enemyTeam="Them"
         neutralWeight={smoke.neutralWeight}
         solve={engineSolveState()}
+        onSolve={() => {}}
         onEditMatrix={() => {}}
       />,
     );
@@ -80,6 +81,7 @@ describe('DraftTrainer (Smoke 4×4, real engine)', () => {
           enemyTeam="Them"
           neutralWeight={smoke.neutralWeight}
           solve={engineSolveState()}
+          onSolve={() => {}}
           onEditMatrix={() => {}}
         />,
       );
@@ -102,6 +104,7 @@ describe('DraftTrainer (Smoke 4×4, real engine)', () => {
         enemyTeam="Them"
         neutralWeight={smoke.neutralWeight}
         solve={engineSolveState()}
+        onSolve={() => {}}
         onEditMatrix={() => {}}
       />,
     );

--- a/web/src/components/DraftTrainer.test.tsx
+++ b/web/src/components/DraftTrainer.test.tsx
@@ -37,8 +37,6 @@ describe('DraftTrainer (Smoke 4×4, real engine)', () => {
         enemyTeam="Them"
         neutralWeight={smoke.neutralWeight}
         solve={engineSolveState()}
-        botStyle="greedy"
-        onBotStyleChange={() => {}}
         onEditMatrix={() => {}}
       />,
     );
@@ -78,8 +76,6 @@ describe('DraftTrainer (Smoke 4×4, real engine)', () => {
           enemyTeam="Them"
           neutralWeight={smoke.neutralWeight}
           solve={engineSolveState()}
-          botStyle="greedy"
-          onBotStyleChange={() => {}}
           onEditMatrix={() => {}}
         />,
       );
@@ -102,8 +98,6 @@ describe('DraftTrainer (Smoke 4×4, real engine)', () => {
         enemyTeam="Them"
         neutralWeight={smoke.neutralWeight}
         solve={engineSolveState()}
-        botStyle="greedy"
-        onBotStyleChange={() => {}}
         onEditMatrix={() => {}}
       />,
     );

--- a/web/src/components/DraftTrainer.test.tsx
+++ b/web/src/components/DraftTrainer.test.tsx
@@ -49,14 +49,16 @@ describe('DraftTrainer (Smoke 4×4, real engine)', () => {
     // The draft board renders for the active round.
     expect(await within(container).findByText(/Our defender · our map/i)).toBeInTheDocument();
 
-    // A 4×4 draft is one round: defender → attackers → refusal.
+    // A 4×4 draft is one round: defender → attackers → refusal. The attackers
+    // step needs two cards picked (individual attackers); the others need one.
     for (let step = 0; step < 3; step++) {
-      const choice = await waitFor(() => {
-        const first = container.querySelector('.choice');
-        if (!first) throw new Error('choices not rendered yet');
-        return first as HTMLElement;
+      await waitFor(() => {
+        if (!container.querySelector('.choice')) throw new Error('choices not rendered yet');
       });
-      await user.click(choice);
+      const cards = () => [...container.querySelectorAll('.choice')] as HTMLElement[];
+      await user.click(cards()[0]);
+      const lockBtn = screen.getByRole('button', { name: /^Lock/ });
+      if (/attackers/.test(lockBtn.textContent ?? '')) await user.click(cards()[1]);
       await user.click(screen.getByRole('button', { name: /^Lock/ }));
     }
 

--- a/web/src/components/DraftTrainer.test.tsx
+++ b/web/src/components/DraftTrainer.test.tsx
@@ -121,6 +121,33 @@ describe('DraftTrainer (Smoke 4×4, real engine)', () => {
     expect(onLiveChange).toHaveBeenLastCalledWith(true);
   });
 
+  test('the attacker-pair "why" list folds into hints — no separate Why toggle', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <DraftTrainer
+        matrix={fixtureMatrix(smoke)}
+        myTeam="Us"
+        enemyTeam="Them"
+        neutralWeight={smoke.neutralWeight}
+        solve={engineSolveState()}
+        onSolve={() => {}}
+        onEditMatrix={() => {}}
+      />,
+    );
+    await user.click(await screen.findByRole('button', { name: /Start practice draft/ }));
+
+    // The "why" content is no longer behind its own toggle.
+    expect(screen.queryByRole('button', { name: 'Why' })).not.toBeInTheDocument();
+
+    // Advance to the attackers stage.
+    await user.click(await waitFor(() => container.querySelector('.choice') as HTMLElement));
+    await user.click(screen.getByRole('button', { name: 'Lock defender' }));
+    await screen.findByRole('button', { name: 'Lock attackers' });
+
+    // Hints are on by default, so the attacker-pair EV list shows automatically.
+    expect(screen.getByText(/Team EV per attacker pair choice/i)).toBeInTheDocument();
+  });
+
   test('undo steps back a decision', async () => {
     const user = userEvent.setup();
     const { container } = render(

--- a/web/src/components/DraftTrainer.test.tsx
+++ b/web/src/components/DraftTrainer.test.tsx
@@ -95,6 +95,32 @@ describe('DraftTrainer (Smoke 4×4, real engine)', () => {
     }
   });
 
+  test('reports draft-live state to onLiveChange', async () => {
+    const user = userEvent.setup();
+    const onLiveChange = vi.fn();
+    const { container } = render(
+      <DraftTrainer
+        matrix={fixtureMatrix(smoke)}
+        myTeam="Us"
+        enemyTeam="Them"
+        neutralWeight={smoke.neutralWeight}
+        solve={engineSolveState()}
+        onSolve={() => {}}
+        onEditMatrix={() => {}}
+        onLiveChange={onLiveChange}
+      />,
+    );
+
+    // Intro screen: no draft in progress yet.
+    expect(onLiveChange).toHaveBeenLastCalledWith(false);
+
+    await user.click(await screen.findByRole('button', { name: /Start practice draft/ }));
+    await waitFor(() => expect(container.querySelector('.choice')).toBeTruthy());
+
+    // A draft is now under way.
+    expect(onLiveChange).toHaveBeenLastCalledWith(true);
+  });
+
   test('undo steps back a decision', async () => {
     const user = userEvent.setup();
     const { container } = render(

--- a/web/src/components/DraftTrainer.test.tsx
+++ b/web/src/components/DraftTrainer.test.tsx
@@ -56,10 +56,12 @@ describe('DraftTrainer (Smoke 4×4, real engine)', () => {
         if (!container.querySelector('.choice')) throw new Error('choices not rendered yet');
       });
       const cards = () => [...container.querySelectorAll('.choice')] as HTMLElement[];
+      // The pairing step's confirm button reads "X faces Y", not "Lock …", so
+      // grab the lock-bar's primary button by position rather than by name.
+      const lockBtn = () => container.querySelector('.lock-bar button') as HTMLButtonElement;
       await user.click(cards()[0]);
-      const lockBtn = screen.getByRole('button', { name: /^Lock/ });
-      if (/attackers/.test(lockBtn.textContent ?? '')) await user.click(cards()[1]);
-      await user.click(screen.getByRole('button', { name: /^Lock/ }));
+      if (/attackers/.test(lockBtn().textContent ?? '')) await user.click(cards()[1]);
+      await user.click(lockBtn());
     }
 
     // Reaching 'done' renders the summary.

--- a/web/src/components/DraftTrainer.tsx
+++ b/web/src/components/DraftTrainer.tsx
@@ -27,7 +27,6 @@ interface DraftTrainerProps {
 const STAGE_COPY = {
   defender: { title: 'Select your defender', sub: 'Both captains put up a defender at the same time.' },
   attackers: { title: 'Send two attackers', sub: 'You send two — the enemy chooses which one your defender faces.' },
-  refusal: { title: 'Refuse an attacker', sub: 'Refuse one of their two attackers; your defender plays the one you keep.' },
 } as const;
 
 function joinName(name: string | [string, string]): string {
@@ -114,7 +113,16 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
   // candidateStats would index an unset defender or pair).
   const modelStage = model.myDefender < 0 ? 'defender' : model.myPair === null ? 'attackers' : 'refusal';
   if (stage !== modelStage) return <p className="placeholder">Loading the next decision…</p>;
-  const copy = STAGE_COPY[stage];
+  // The refusal step is framed as selecting who your defender faces (people
+  // think in matchups, not refusals), so its copy needs the defender's name.
+  const defenderName = myNames[model.myDefender];
+  const copy =
+    stage === 'refusal'
+      ? {
+          title: `Choose whom ${defenderName} will face`,
+          sub: `Pick which of their two attackers ${defenderName} plays — the other is refused.`,
+        }
+      : STAGE_COPY[stage];
   const proj = projectedResult(model, node, expected);
   // EV cards + the projected header share one scale: the 0–20n team total, one
   // decimal. The best card's EV therefore equals the projected figure exactly.
@@ -148,11 +156,17 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
     setSelected(null);
     setAttackerSel([]);
     setShowWhy(false);
-    setReveal(
-      stage === 'refusal'
-        ? { mine: `refuse ${myLabel}`, enemy: `refuse ${enemyLabel}` }
-        : { mine: myLabel, enemy: enemyLabel },
-    );
+    if (stage === 'refusal') {
+      // Framed as who each defender faces: I keep the enemy attacker I didn't
+      // refuse; the enemy's defender faces the friendly attacker they didn't.
+      const iRefuse = node.choices[myChoice].id as number;
+      const myFaces = model.enemyPair!.find((x) => x !== iRefuse)!;
+      const enemyRefuses = model.myPair![colIndex];
+      const enemyFaces = model.myPair!.find((x) => x !== enemyRefuses)!;
+      setReveal({ mine: `face ${enemyNames[myFaces]}`, enemy: `face ${myNames[enemyFaces]}` });
+    } else {
+      setReveal({ mine: myLabel, enemy: enemyLabel });
+    }
     if (next.done) setNode(null);
     else solve.node(next.path).then(setNode).catch(() => {});
   };
@@ -245,7 +259,7 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
                   {showHints && (
                     <span className="chint">
                       <span className="cbar"><span style={{ width: `${Math.min(100, opt.sendProb * 100)}%` }} /></span>
-                      <span className="csend">sent {(opt.sendProb * 100).toFixed(0)}%</span>
+                      <span className="csend">{(opt.sendProb * 100).toFixed(0)}%</span>
                     </span>
                   )}
                 </button>
@@ -274,6 +288,9 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
         <div className="choices grid">
           {node.choices.map((choice, i) => {
             const stats = candidateStats(model, node, i);
+            // Refusal cards are framed as who my defender faces: show the enemy
+            // attacker I'd keep (i.e. not refuse — choice.id is the refused one).
+            const faced = stage === 'refusal' ? model.enemyPair!.find((x) => x !== (choice.id as number))! : -1;
             return (
               <button
                 key={i}
@@ -281,11 +298,13 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
                 onClick={() => setSelected(i)}
               >
                 <span className="cname">
-                  {stage === 'refusal' ? `Refuse ${joinName(choice.name)}` : joinName(choice.name)}
+                  {stage === 'refusal' ? enemyNames[faced] : joinName(choice.name)}
                 </span>
                 <span className="cstat">
                   our map ·{' '}
-                  {stats.avg === stats.floor ? (
+                  {stage === 'refusal' ? (
+                    <span className={`num band-${scoreBand(stats.avg)}`}>{stats.avg}</span>
+                  ) : stats.avg === stats.floor ? (
                     <>keeps <span className={`num band-${scoreBand(stats.avg)}`}>{stats.avg}</span></>
                   ) : (
                     <>

--- a/web/src/components/DraftTrainer.tsx
+++ b/web/src/components/DraftTrainer.tsx
@@ -1,6 +1,5 @@
 import { useRef, useState } from 'react';
 import type { Matrix, NodeResult } from '../engine/types';
-import type { BotStyle } from '../draft/sampling';
 import { sampleIndex } from '../draft/sampling';
 import type { DraftModel } from '../draft/draftState';
 import { applyStep, initDraft } from '../draft/draftState';
@@ -22,8 +21,6 @@ interface DraftTrainerProps {
   enemyTeam: string;
   neutralWeight: number;
   solve: SolveState;
-  botStyle: BotStyle;
-  onBotStyleChange: (style: BotStyle) => void;
   onEditMatrix: () => void;
 }
 
@@ -37,7 +34,7 @@ function joinName(name: string | [string, string]): string {
   return typeof name === 'string' ? name : `${name[0]} + ${name[1]}`;
 }
 
-export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, botStyle, onBotStyleChange, onEditMatrix }: DraftTrainerProps) {
+export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, onEditMatrix }: DraftTrainerProps) {
   const { myNames, enemyNames } = matrix;
   const [model, setModel] = useState<DraftModel | null>(null);
   const [history, setHistory] = useState<DraftModel[]>([]);
@@ -122,7 +119,7 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
 
   const lock = () => {
     if (selected === null || !node.why) return;
-    const colIndex = sampleIndex(node.why.enStrategy, botStyle, rng.current);
+    const colIndex = sampleIndex(node.why.enStrategy, 'equilibrium', rng.current);
     const myLabel = joinName(node.choices[selected].name);
     const enemyLabel = node.why.colLabels[colIndex];
     const next = applyStep(model, node, selected, colIndex);
@@ -152,7 +149,27 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
 
   return (
     <div className="trainer">
-      <PhaseStepper stage={stage} />
+      <div className="trainer-topbar">
+        <PhaseStepper stage={stage} />
+        <div className="trainer-controls">
+          <button
+            className={showHints ? 'tab active' : 'tab'}
+            onClick={() => setHints((h) => !h)}
+            disabled={!hintsAllowed}
+            title={hintsAllowed ? undefined : 'Coaching hints are off during official WTC dates'}
+          >
+            Hints: {showHints ? 'on' : 'off'}
+          </button>
+          <button
+            className={showWhy ? 'tab active' : 'tab'}
+            onClick={() => setShowWhy((w) => !w)}
+            disabled={!node.why || !hintsAllowed}
+          >
+            Why
+          </button>
+          <button onClick={undo} disabled={history.length === 0}>↩ Undo</button>
+        </div>
+      </div>
       <div className="trainer-head">
         <h2>{copy.title}</h2>
         <span className="round-badge">Round {node.round} / {finalRound}</span>
@@ -167,34 +184,6 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
         )}
       </div>
       <p className="trainer-sub">{copy.sub}</p>
-
-      <div className="trainer-controls">
-        <label className="style-select">
-          Bot
-          <select value={botStyle} onChange={(e) => onBotStyleChange(e.target.value as BotStyle)}>
-            <option value="equilibrium">Equilibrium</option>
-            <option value="greedy">Greedy</option>
-            <option value="wildcard">Wildcard</option>
-          </select>
-        </label>
-        <button
-          className={showHints ? 'tab active' : 'tab'}
-          onClick={() => setHints((h) => !h)}
-          disabled={!hintsAllowed}
-          title={hintsAllowed ? undefined : 'Coaching hints are off during official WTC dates'}
-        >
-          Hints: {showHints ? 'on' : 'off'}
-        </button>
-        <button
-          className={showWhy ? 'tab active' : 'tab'}
-          onClick={() => setShowWhy((w) => !w)}
-          disabled={!node.why || !hintsAllowed}
-        >
-          Why
-        </button>
-        <span className="spacer" />
-        <button onClick={undo} disabled={history.length === 0}>↩ Undo</button>
-      </div>
 
       {wtcLock && (
         <div className="wtc-note">

--- a/web/src/components/DraftTrainer.tsx
+++ b/web/src/components/DraftTrainer.tsx
@@ -131,6 +131,15 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
       : selected !== null
         ? `${defenderName} faces ${enemyNames[model.enemyPair!.find((x) => x !== (node.choices[selected].id as number))!]}`
         : `${defenderName} faces …`;
+  // In-progress picks so the board fills + highlights before the user locks.
+  const pending = {
+    defender: stage === 'defender' && selected !== null ? (node.choices[selected].id as number) : null,
+    attackers: stage === 'attackers' ? attackerSel : [],
+    face:
+      stage === 'refusal' && selected !== null
+        ? model.enemyPair!.find((x) => x !== (node.choices[selected].id as number))!
+        : null,
+  };
   const proj = projectedResult(model, node, expected);
   // EV cards + the projected header share one scale: the 0–20n team total, one
   // decimal. The best card's EV therefore equals the projected figure exactly.
@@ -243,7 +252,7 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
         </div>
       )}
 
-      <DraftBoard model={model} myNames={myNames} enemyNames={enemyNames} stage={stage} />
+      <DraftBoard model={model} myNames={myNames} enemyNames={enemyNames} pending={pending} />
 
       {stage === 'attackers' ? (
         <>

--- a/web/src/components/DraftTrainer.tsx
+++ b/web/src/components/DraftTrainer.tsx
@@ -1,10 +1,10 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { Matrix, NodeResult } from '../engine/types';
 import { sampleIndex } from '../draft/sampling';
-import type { DraftModel } from '../draft/draftState';
+import type { DraftModel, FixedGame } from '../draft/draftState';
 import { applyStep, initDraft } from '../draft/draftState';
 import { attackerOptions, candidateStats, pairChoiceIndex, projectedResult } from '../draft/cards';
-import { formatTeamScore, scoreBand, teamTotal, toScore } from '../model/scale';
+import { formatMatchupScore, formatTeamScore, scoreBand, teamTotal, toScore } from '../model/scale';
 import { activeWtcEvent } from '../model/wtcDates';
 import type { SolveState } from '../worker/useSolve';
 import { DraftBoard } from './DraftBoard';
@@ -21,6 +21,8 @@ interface DraftTrainerProps {
   enemyTeam: string;
   neutralWeight: number;
   solve: SolveState;
+  /** Trigger an exact solve on demand (from "Start practice draft"). */
+  onSolve: () => void;
   onEditMatrix: () => void;
 }
 
@@ -29,11 +31,21 @@ const STAGE_COPY = {
   attackers: { title: 'Send two attackers', sub: 'You send two — the enemy chooses which one your defender faces.' },
 } as const;
 
+// Which map a resolved game is played on: the defender picks it, so my-defends
+// is my best map and enemy-defends is theirs (my worst); the refused / last
+// games have no defender (a 50/50 best↔worst average), so they're neutral.
+const MAP_LABEL: Record<FixedGame['kind'], string> = {
+  'my-defends': 'your map',
+  'enemy-defends': 'their map',
+  refused: 'neutral',
+  last: 'neutral',
+};
+
 function joinName(name: string | [string, string]): string {
   return typeof name === 'string' ? name : `${name[0]} + ${name[1]}`;
 }
 
-export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, onEditMatrix }: DraftTrainerProps) {
+export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, onSolve, onEditMatrix }: DraftTrainerProps) {
   const { myNames, enemyNames } = matrix;
   const [model, setModel] = useState<DraftModel | null>(null);
   const [history, setHistory] = useState<DraftModel[]>([]);
@@ -44,6 +56,9 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
   const [attackerSel, setAttackerSel] = useState<number[]>([]);
   const [showWhy, setShowWhy] = useState(false);
   const [hints, setHints] = useState(true);
+  // Set by "Start practice draft"; the draft begins once the on-demand solve is
+  // ready. Keeps the solve off the tab-open path.
+  const [wantStart, setWantStart] = useState(false);
   const rng = useRef<() => number>(Math.random);
 
   const ready = solve.status === 'done' && solve.solvedK === null;
@@ -56,15 +71,23 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
   const hintsAllowed = wtcLock === null;
   const showHints = hints && hintsAllowed;
 
+  // "Start practice draft" kicks off the exact solve on demand (it no longer
+  // runs when the Trainer tab opens); the draft begins once the values land.
   const start = () => {
-    if (!ready) return;
+    if (!ready) onSolve();
+    setWantStart(true);
+  };
+  useEffect(() => {
+    if (!(ready && wantStart)) return;
+    setWantStart(false);
     setModel(initDraft(matrix, neutralWeight));
     setHistory([]);
     setSelected(null);
     setAttackerSel([]);
     setShowWhy(false);
     solve.node([]).then(setNode).catch(() => {});
-  };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ready, wantStart]);
 
   // --- intro ---
   if (model === null) {
@@ -81,8 +104,8 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
           <li>Runs entirely on your computer — your matrix and drafts are never uploaded. Hints are training-only and switch off during official WTC dates.</li>
         </ul>
         {solve.status === 'solving' && <ProgressBar frac={solve.progress} label="Solving exactly for training…" />}
-        <button className="primary" disabled={!ready} onClick={start}>Start practice draft</button>
-        {!ready && solve.status !== 'solving' && <span className="muted"> Solve the matrix first.</span>}
+        <button className="primary" disabled={solve.status === 'solving'} onClick={start}>Start practice draft</button>
+        {solve.status === 'error' && <span className="muted"> Solve failed — {solve.error}</span>}
       </div>
     );
   }
@@ -340,8 +363,9 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
               return (
                 <div className="pairing" key={i}>
                   <span className="pmine">{myNames[game.my]}</span>
-                  <span className="pscore">{my.toFixed(1)}–{(20 - my).toFixed(1)}</span>
+                  <span className="pscore">{formatMatchupScore(my)}–{formatMatchupScore(20 - my)}</span>
                   <span className="penemy">{enemyNames[game.enemy]}</span>
+                  <span className="pkind">{MAP_LABEL[game.kind]}</span>
                 </div>
               );
             })}

--- a/web/src/components/DraftTrainer.tsx
+++ b/web/src/components/DraftTrainer.tsx
@@ -24,6 +24,9 @@ interface DraftTrainerProps {
   /** Trigger an exact solve on demand (from "Start practice draft"). */
   onSolve: () => void;
   onEditMatrix: () => void;
+  /** Notifies the app when a draft is in progress (not done), so it can lock the
+   * Matrix tab while the draft depends on its numbers. */
+  onLiveChange?: (live: boolean) => void;
 }
 
 const STAGE_COPY = {
@@ -45,7 +48,7 @@ function joinName(name: string | [string, string]): string {
   return typeof name === 'string' ? name : `${name[0]} + ${name[1]}`;
 }
 
-export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, onSolve, onEditMatrix }: DraftTrainerProps) {
+export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, onSolve, onEditMatrix, onLiveChange }: DraftTrainerProps) {
   const { myNames, enemyNames } = matrix;
   const [model, setModel] = useState<DraftModel | null>(null);
   const [history, setHistory] = useState<DraftModel[]>([]);
@@ -88,6 +91,13 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
     solve.node([]).then(setNode).catch(() => {});
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ready, wantStart]);
+
+  // A draft is "live" once it exists and isn't finished. The app lifts this to
+  // lock the Matrix tab (its numbers must stay fixed for the running draft).
+  const isLive = model !== null && !model.done;
+  useEffect(() => {
+    onLiveChange?.(isLive);
+  }, [isLive, onLiveChange]);
 
   // --- intro ---
   if (model === null) {

--- a/web/src/components/DraftTrainer.tsx
+++ b/web/src/components/DraftTrainer.tsx
@@ -3,7 +3,7 @@ import type { Matrix, NodeResult } from '../engine/types';
 import { sampleIndex } from '../draft/sampling';
 import type { DraftModel } from '../draft/draftState';
 import { applyStep, initDraft } from '../draft/draftState';
-import { candidateStats, projectedResult } from '../draft/cards';
+import { attackerOptions, candidateStats, pairChoiceIndex, projectedResult } from '../draft/cards';
 import { formatTeamScore, scoreBand, teamTotal, toScore } from '../model/scale';
 import { activeWtcEvent } from '../model/wtcDates';
 import type { SolveState } from '../worker/useSolve';
@@ -40,6 +40,9 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
   const [history, setHistory] = useState<DraftModel[]>([]);
   const [node, setNode] = useState<NodeResult | null>(null);
   const [selected, setSelected] = useState<number | null>(null);
+  // Attackers stage only: the (≤2) individually-picked attacker indices. Other
+  // stages select a single choice via `selected`.
+  const [attackerSel, setAttackerSel] = useState<number[]>([]);
   const [reveal, setReveal] = useState<{ mine: string; enemy: string } | null>(null);
   const [showWhy, setShowWhy] = useState(false);
   const [hints, setHints] = useState(true);
@@ -60,6 +63,7 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
     setModel(initDraft(matrix, neutralWeight));
     setHistory([]);
     setSelected(null);
+    setAttackerSel([]);
     setReveal(null);
     setShowWhy(false);
     solve.node([]).then(setNode).catch(() => {});
@@ -117,15 +121,32 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
   const achieved = model.fixed.reduce((sum, g) => sum + g.value, 0);
   const projScore = formatTeamScore(teamTotal(proj.projected, model.n));
 
+  // Attackers select two individual cards (resolved to the pair NodeChoice on
+  // lock); every other stage selects a single choice.
+  const canLock = stage === 'attackers' ? attackerSel.length === 2 : selected !== null;
+
+  const toggleAttacker = (idx: number) => {
+    setAttackerSel((sel) =>
+      sel.includes(idx)
+        ? sel.filter((x) => x !== idx)
+        : sel.length < 2
+          ? [...sel, idx]
+          : [sel[1], idx], // already two picked → drop the earliest, keep the newest
+    );
+  };
+
   const lock = () => {
-    if (selected === null || !node.why) return;
+    const myChoice =
+      stage === 'attackers' ? pairChoiceIndex(node, attackerSel[0], attackerSel[1]) : selected ?? -1;
+    if (myChoice < 0 || !node.why) return;
     const colIndex = sampleIndex(node.why.enStrategy, 'equilibrium', rng.current);
-    const myLabel = joinName(node.choices[selected].name);
+    const myLabel = joinName(node.choices[myChoice].name);
     const enemyLabel = node.why.colLabels[colIndex];
-    const next = applyStep(model, node, selected, colIndex);
+    const next = applyStep(model, node, myChoice, colIndex);
     setHistory([...history, model]);
     setModel(next);
     setSelected(null);
+    setAttackerSel([]);
     setShowWhy(false);
     setReveal(
       stage === 'refusal'
@@ -142,6 +163,7 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
     setHistory(history.slice(0, -1));
     setModel(prev);
     setSelected(null);
+    setAttackerSel([]);
     setReveal(null);
     setShowWhy(false);
     solve.node(prev.path).then(setNode).catch(() => {});
@@ -201,43 +223,92 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
 
       <DraftBoard model={model} myNames={myNames} enemyNames={enemyNames} stage={stage} />
 
-      <div className="choices grid">
-        {node.choices.map((choice, i) => {
-          const stats = candidateStats(model, node, i);
-          return (
-            <button
-              key={i}
-              className={selected === i ? 'choice selected' : 'choice'}
-              onClick={() => setSelected(i)}
-            >
-              <span className="cname">
-                {stage === 'refusal' ? `Refuse ${joinName(choice.name)}` : joinName(choice.name)}
-              </span>
-              <span className="cstat">
-                our map ·{' '}
-                {stats.avg === stats.floor ? (
-                  <>keeps <span className={`num band-${scoreBand(stats.avg)}`}>{stats.avg}</span></>
-                ) : (
-                  <>
-                    avg <span className={`num band-${scoreBand(stats.avg)}`}>{stats.avg}</span>
-                    {' · '}floor <span className={`num band-${scoreBand(stats.floor)}`}>{stats.floor}</span>
-                  </>
-                )}
-              </span>
-              {showHints && (
-                <span className="chint">
-                  <span className="cbar"><span style={{ width: `${Math.min(100, choice.prob * 100)}%` }} /></span>
-                  <span className="cprob">{(choice.prob * 100).toFixed(0)}%</span>
-                  <span className="cev">EV {formatTeamScore(teamTotal(achieved + choice.ev, model.n))}</span>
+      {stage === 'attackers' ? (
+        <>
+          <div className="choices grid">
+            {attackerOptions(model, node).map((opt) => {
+              const sel = attackerSel.includes(opt.index);
+              return (
+                <button
+                  key={opt.index}
+                  className={sel ? 'choice selected' : 'choice'}
+                  aria-pressed={sel}
+                  onClick={() => toggleAttacker(opt.index)}
+                >
+                  <span className="cname">
+                    {myNames[opt.index]}
+                    {sel && <span className="tick" aria-hidden="true">✓</span>}
+                  </span>
+                  <span className="cstat">
+                    their map · <span className={`num band-${scoreBand(opt.rating)}`}>{opt.rating}</span>
+                  </span>
+                  {showHints && (
+                    <span className="chint">
+                      <span className="cbar"><span style={{ width: `${Math.min(100, opt.sendProb * 100)}%` }} /></span>
+                      <span className="csend">sent {(opt.sendProb * 100).toFixed(0)}%</span>
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+          {showHints && attackerSel.length === 2 && (() => {
+            const ci = pairChoiceIndex(node, attackerSel[0], attackerSel[1]);
+            if (ci < 0) return null;
+            const c = node.choices[ci];
+            const bestEv = node.choices.reduce((m, ch) => Math.max(m, ch.ev), -Infinity);
+            const regret = c.ev - bestEv; // ≤ 0; 0 means this pair is an equilibrium best
+            return (
+              <div className="pair-summary">
+                <span className="ps-label">Your pair</span>
+                <span className="ps-names">{joinName(c.name)}</span>
+                <span className="ps-fig">
+                  {(c.prob * 100).toFixed(0)}% of equilibrium · EV {formatTeamScore(teamTotal(achieved + c.ev, model.n))}
                 </span>
-              )}
-            </button>
-          );
-        })}
-      </div>
+                {regret < -0.05 && <span className="ps-regret">{regret.toFixed(1)} vs best</span>}
+              </div>
+            );
+          })()}
+        </>
+      ) : (
+        <div className="choices grid">
+          {node.choices.map((choice, i) => {
+            const stats = candidateStats(model, node, i);
+            return (
+              <button
+                key={i}
+                className={selected === i ? 'choice selected' : 'choice'}
+                onClick={() => setSelected(i)}
+              >
+                <span className="cname">
+                  {stage === 'refusal' ? `Refuse ${joinName(choice.name)}` : joinName(choice.name)}
+                </span>
+                <span className="cstat">
+                  our map ·{' '}
+                  {stats.avg === stats.floor ? (
+                    <>keeps <span className={`num band-${scoreBand(stats.avg)}`}>{stats.avg}</span></>
+                  ) : (
+                    <>
+                      avg <span className={`num band-${scoreBand(stats.avg)}`}>{stats.avg}</span>
+                      {' · '}floor <span className={`num band-${scoreBand(stats.floor)}`}>{stats.floor}</span>
+                    </>
+                  )}
+                </span>
+                {showHints && (
+                  <span className="chint">
+                    <span className="cbar"><span style={{ width: `${Math.min(100, choice.prob * 100)}%` }} /></span>
+                    <span className="cprob">{(choice.prob * 100).toFixed(0)}%</span>
+                    <span className="cev">EV {formatTeamScore(teamTotal(achieved + choice.ev, model.n))}</span>
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
 
       <div className="lock-bar">
-        <button className="primary" disabled={selected === null} onClick={lock}>Lock {stage}</button>
+        <button className="primary" disabled={!canLock} onClick={lock}>Lock {stage}</button>
         <span className="muted">{enemy} picks simultaneously — revealed after you lock.</span>
       </div>
 

--- a/web/src/components/DraftTrainer.tsx
+++ b/web/src/components/DraftTrainer.tsx
@@ -123,6 +123,14 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
           sub: `Pick which of their two attackers ${defenderName} plays — the other is refused.`,
         }
       : STAGE_COPY[stage];
+  // The pairing (refusal) confirm button states the matchup it locks in
+  // ("X faces Y"); other stages keep the generic "Lock <stage>".
+  const lockLabel =
+    stage !== 'refusal'
+      ? `Lock ${stage}`
+      : selected !== null
+        ? `${defenderName} faces ${enemyNames[model.enemyPair!.find((x) => x !== (node.choices[selected].id as number))!]}`
+        : `${defenderName} faces …`;
   const proj = projectedResult(model, node, expected);
   // EV cards + the projected header share one scale: the 0–20n team total, one
   // decimal. The best card's EV therefore equals the projected figure exactly.
@@ -327,7 +335,7 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
       )}
 
       <div className="lock-bar">
-        <button className="primary" disabled={!canLock} onClick={lock}>Lock {stage}</button>
+        <button className="primary" disabled={!canLock} onClick={lock}>{lockLabel}</button>
         <span className="muted">{enemy} picks simultaneously — revealed after you lock.</span>
       </div>
 

--- a/web/src/components/DraftTrainer.tsx
+++ b/web/src/components/DraftTrainer.tsx
@@ -42,7 +42,6 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
   // Attackers stage only: the (≤2) individually-picked attacker indices. Other
   // stages select a single choice via `selected`.
   const [attackerSel, setAttackerSel] = useState<number[]>([]);
-  const [reveal, setReveal] = useState<{ mine: string; enemy: string } | null>(null);
   const [showWhy, setShowWhy] = useState(false);
   const [hints, setHints] = useState(true);
   const rng = useRef<() => number>(Math.random);
@@ -63,7 +62,6 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
     setHistory([]);
     setSelected(null);
     setAttackerSel([]);
-    setReveal(null);
     setShowWhy(false);
     solve.node([]).then(setNode).catch(() => {});
   };
@@ -165,25 +163,12 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
       stage === 'attackers' ? pairChoiceIndex(node, attackerSel[0], attackerSel[1]) : selected ?? -1;
     if (myChoice < 0 || !node.why) return;
     const colIndex = sampleIndex(node.why.enStrategy, 'equilibrium', rng.current);
-    const myLabel = joinName(node.choices[myChoice].name);
-    const enemyLabel = node.why.colLabels[colIndex];
     const next = applyStep(model, node, myChoice, colIndex);
     setHistory([...history, model]);
     setModel(next);
     setSelected(null);
     setAttackerSel([]);
     setShowWhy(false);
-    if (stage === 'refusal') {
-      // Framed as who each defender faces: I keep the enemy attacker I didn't
-      // refuse; the enemy's defender faces the friendly attacker they didn't.
-      const iRefuse = node.choices[myChoice].id as number;
-      const myFaces = model.enemyPair!.find((x) => x !== iRefuse)!;
-      const enemyRefuses = model.myPair![colIndex];
-      const enemyFaces = model.myPair!.find((x) => x !== enemyRefuses)!;
-      setReveal({ mine: `face ${enemyNames[myFaces]}`, enemy: `face ${myNames[enemyFaces]}` });
-    } else {
-      setReveal({ mine: myLabel, enemy: enemyLabel });
-    }
     if (next.done) setNode(null);
     else solve.node(next.path).then(setNode).catch(() => {});
   };
@@ -195,7 +180,6 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
     setModel(prev);
     setSelected(null);
     setAttackerSel([]);
-    setReveal(null);
     setShowWhy(false);
     solve.node(prev.path).then(setNode).catch(() => {});
   };
@@ -242,13 +226,6 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
         <div className="wtc-note">
           Coaching hints are off — <strong>{wtcLock.name}</strong> is under way. They switch back
           on automatically after the event.
-        </div>
-      )}
-
-      {reveal && (
-        <div className="reveal">
-          <span>You: <span className="r-mine">{reveal.mine}</span></span>
-          <span>{enemy}: <span className="r-enemy">{reveal.enemy}</span></span>
         </div>
       )}
 

--- a/web/src/components/DraftTrainer.tsx
+++ b/web/src/components/DraftTrainer.tsx
@@ -57,7 +57,6 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
   // Attackers stage only: the (≤2) individually-picked attacker indices. Other
   // stages select a single choice via `selected`.
   const [attackerSel, setAttackerSel] = useState<number[]>([]);
-  const [showWhy, setShowWhy] = useState(false);
   const [hints, setHints] = useState(true);
   // Set by "Start practice draft"; the draft begins once the on-demand solve is
   // ready. Keeps the solve off the tab-open path.
@@ -87,7 +86,6 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
     setHistory([]);
     setSelected(null);
     setAttackerSel([]);
-    setShowWhy(false);
     solve.node([]).then(setNode).catch(() => {});
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ready, wantStart]);
@@ -201,7 +199,6 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
     setModel(next);
     setSelected(null);
     setAttackerSel([]);
-    setShowWhy(false);
     if (next.done) setNode(null);
     else solve.node(next.path).then(setNode).catch(() => {});
   };
@@ -213,7 +210,6 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
     setModel(prev);
     setSelected(null);
     setAttackerSel([]);
-    setShowWhy(false);
     solve.node(prev.path).then(setNode).catch(() => {});
   };
 
@@ -229,13 +225,6 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
             title={hintsAllowed ? undefined : 'Coaching hints are off during official WTC dates'}
           >
             Hints: {showHints ? 'on' : 'off'}
-          </button>
-          <button
-            className={showWhy ? 'tab active' : 'tab'}
-            onClick={() => setShowWhy((w) => !w)}
-            disabled={!node.why || !hintsAllowed}
-          >
-            Why
           </button>
           <button onClick={undo} disabled={history.length === 0}>↩ Undo</button>
         </div>
@@ -358,7 +347,7 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
         <span className="muted">{enemy} picks simultaneously — revealed after you lock.</span>
       </div>
 
-      {showWhy && hintsAllowed && <WhyPanel node={node} model={model} myNames={myNames} enemyNames={enemyNames} />}
+      {showHints && <WhyPanel node={node} model={model} />}
 
       <RemainingMatchups model={model} myNames={myNames} enemyNames={enemyNames} />
 

--- a/web/src/components/DraftTrainer.tsx
+++ b/web/src/components/DraftTrainer.tsx
@@ -5,7 +5,7 @@ import { sampleIndex } from '../draft/sampling';
 import type { DraftModel } from '../draft/draftState';
 import { applyStep, initDraft } from '../draft/draftState';
 import { candidateStats, projectedResult } from '../draft/cards';
-import { formatTeamScore, teamTotal, toScore } from '../model/scale';
+import { formatTeamScore, scoreBand, teamTotal, toScore } from '../model/scale';
 import { activeWtcEvent } from '../model/wtcDates';
 import type { SolveState } from '../worker/useSolve';
 import { DraftBoard } from './DraftBoard';
@@ -225,7 +225,15 @@ export function DraftTrainer({ matrix, myTeam, enemyTeam, neutralWeight, solve, 
                 {stage === 'refusal' ? `Refuse ${joinName(choice.name)}` : joinName(choice.name)}
               </span>
               <span className="cstat">
-                our map · {stats.avg === stats.floor ? `keeps ${stats.avg}` : `avg ${stats.avg} · floor ${stats.floor}`}
+                our map ·{' '}
+                {stats.avg === stats.floor ? (
+                  <>keeps <span className={`num band-${scoreBand(stats.avg)}`}>{stats.avg}</span></>
+                ) : (
+                  <>
+                    avg <span className={`num band-${scoreBand(stats.avg)}`}>{stats.avg}</span>
+                    {' · '}floor <span className={`num band-${scoreBand(stats.floor)}`}>{stats.floor}</span>
+                  </>
+                )}
               </span>
               {showHints && (
                 <span className="chint">

--- a/web/src/components/Grid.tsx
+++ b/web/src/components/Grid.tsx
@@ -5,6 +5,8 @@ interface GridProps {
   matrix: EditorMatrix;
   simpleMode: boolean;
   cellErrors: (string | null)[][];
+  /** Freeze every input (names + cells) — set while a draft locks the matrix. */
+  readOnly?: boolean;
   onCellChange: (i: number, j: number, cell: EditorCell) => void;
   onMyName: (i: number, name: string) => void;
   onEnemyName: (j: number, name: string) => void;
@@ -20,7 +22,7 @@ function bandClass(raw: string): string {
 }
 
 export function Grid({
-  matrix, simpleMode, cellErrors, onCellChange, onMyName, onEnemyName,
+  matrix, simpleMode, cellErrors, readOnly = false, onCellChange, onMyName, onEnemyName,
 }: GridProps) {
   const { myNames, enemyNames, cells } = matrix;
 
@@ -37,6 +39,7 @@ export function Grid({
                   value={name}
                   placeholder={`Enemy ${j + 1}`}
                   aria-label={`Enemy player ${j + 1} name`}
+                  readOnly={readOnly}
                   onChange={(e) => onEnemyName(j, e.target.value)}
                 />
               </th>
@@ -52,6 +55,7 @@ export function Grid({
                   value={rowName}
                   placeholder={`Player ${i + 1}`}
                   aria-label={`Your player ${i + 1} name`}
+                  readOnly={readOnly}
                   onChange={(e) => onMyName(i, e.target.value)}
                 />
               </th>
@@ -70,6 +74,7 @@ export function Grid({
                         value={cell.b}
                         aria-label={label}
                         inputMode="decimal"
+                        readOnly={readOnly}
                         onChange={(e) => onCellChange(i, j, { b: e.target.value, w: e.target.value })}
                       />
                     ) : (
@@ -79,6 +84,7 @@ export function Grid({
                           value={cell.b}
                           aria-label={`${label} best`}
                           inputMode="decimal"
+                          readOnly={readOnly}
                           onChange={(e) => onCellChange(i, j, { ...cell, b: e.target.value })}
                         />
                         <span className="sep">/</span>
@@ -87,6 +93,7 @@ export function Grid({
                           value={cell.w}
                           aria-label={`${label} worst`}
                           inputMode="decimal"
+                          readOnly={readOnly}
                           onChange={(e) => onCellChange(i, j, { ...cell, w: e.target.value })}
                         />
                       </div>

--- a/web/src/components/MatrixEditor.test.tsx
+++ b/web/src/components/MatrixEditor.test.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { blank } from '../model/matrix';
 import type { EditorMatrix } from '../model/matrix';
 import type { Settings } from '../model/storage';
@@ -60,6 +60,36 @@ describe('MatrixEditor', () => {
     await user.clear(bestInput); // best now blank -> invalid
     await user.type(bestInput, '5'); // best 5 < worst 9
     expect(screen.getByRole('button', { name: /solve/i })).toBeDisabled();
+  });
+
+  test('locked shows the draft warning, freezes the grid, and discards on demand', async () => {
+    const user = userEvent.setup();
+    const onDiscardDraft = vi.fn();
+    render(
+      <MatrixEditor
+        matrix={valid4()}
+        settings={{ cb: false, simpleMode: false }}
+        saves={{}}
+        onMatrixChange={() => {}}
+        onSettingsChange={() => {}}
+        onSaveAs={() => {}}
+        onLoadSave={() => {}}
+        onDeleteSave={() => {}}
+        onSolve={() => {}}
+        locked
+        onDiscardDraft={onDiscardDraft}
+      />,
+    );
+
+    // Warning banner explaining why editing is paused.
+    expect(screen.getByText(/practice draft is in progress/i)).toBeInTheDocument();
+    // The grid is frozen and Solve is disabled while a draft depends on it.
+    expect(screen.getByLabelText('A vs W best')).toHaveAttribute('readonly');
+    expect(screen.getByRole('button', { name: /solve/i })).toBeDisabled();
+
+    // "Discard draft to edit" discards immediately — no confirmation dialog.
+    await user.click(screen.getByRole('button', { name: /discard draft to edit/i }));
+    expect(onDiscardDraft).toHaveBeenCalledTimes(1);
   });
 
   test('switching to single-rating mode collapses cells to one input', async () => {

--- a/web/src/components/MatrixEditor.test.tsx
+++ b/web/src/components/MatrixEditor.test.tsx
@@ -69,7 +69,7 @@ describe('MatrixEditor', () => {
       <MatrixEditor
         matrix={valid4()}
         settings={{ cb: false, simpleMode: false }}
-        saves={{}}
+        saves={{ Scotland: valid4() }}
         onMatrixChange={() => {}}
         onSettingsChange={() => {}}
         onSaveAs={() => {}}
@@ -86,6 +86,9 @@ describe('MatrixEditor', () => {
     // The grid is frozen and Solve is disabled while a draft depends on it.
     expect(screen.getByLabelText('A vs W best')).toHaveAttribute('readonly');
     expect(screen.getByRole('button', { name: /solve/i })).toBeDisabled();
+    // Saved-opponent load AND delete are frozen too — the whole editor is paused.
+    expect(screen.getByRole('button', { name: 'Scotland' })).toBeDisabled();
+    expect(screen.getByTitle('Delete Scotland')).toBeDisabled();
 
     // "Discard draft to edit" discards immediately — no confirmation dialog.
     await user.click(screen.getByRole('button', { name: /discard draft to edit/i }));

--- a/web/src/components/MatrixEditor.tsx
+++ b/web/src/components/MatrixEditor.tsx
@@ -21,6 +21,12 @@ interface MatrixEditorProps {
   onDeleteSave: (name: string) => void;
   /** Provided once the solve view exists (#20); undefined disables the CTA. */
   onSolve?: () => void;
+  /** True while a practice draft depends on this matrix: the editor freezes so
+   * its numbers can't drift out from under the running draft/solver. */
+  locked?: boolean;
+  /** Discards the in-progress draft (immediately, no confirm) to re-enable
+   * editing. Only rendered/used while `locked`. */
+  onDiscardDraft?: () => void;
 }
 
 function download(filename: string, text: string): void {
@@ -36,7 +42,7 @@ function download(filename: string, text: string): void {
 
 export function MatrixEditor({
   matrix, settings, saves, onMatrixChange, onSettingsChange,
-  onSaveAs, onLoadSave, onDeleteSave, onSolve,
+  onSaveAs, onLoadSave, onDeleteSave, onSolve, locked = false, onDiscardDraft,
 }: MatrixEditorProps) {
   const [saveName, setSaveName] = useState('');
   const [pasteOpen, setPasteOpen] = useState(false);
@@ -86,7 +92,20 @@ export function MatrixEditor({
   const savedNames = Object.keys(saves);
 
   return (
-    <div className="editor">
+    <>
+      {locked && (
+        <div className="draft-lock">
+          <span className="draft-lock-dot" aria-hidden="true" />
+          <span className="draft-lock-text">
+            A practice draft is in progress — matrix editing is paused so your draft and
+            solver stay consistent with the numbers you drafted on.
+          </span>
+          <button className="draft-lock-discard" onClick={onDiscardDraft}>
+            Discard draft to edit
+          </button>
+        </div>
+      )}
+      <div className="editor">
       <aside className="editor-sidebar">
         <div>
           <div className="section-head">Saved opponents</div>
@@ -96,7 +115,7 @@ export function MatrixEditor({
             <div className="saved-list">
               {savedNames.map((name) => (
                 <div className="saved-row" key={name}>
-                  <button className="load" onClick={() => onLoadSave(name)}>{name}</button>
+                  <button className="load" disabled={locked} onClick={() => onLoadSave(name)}>{name}</button>
                   <button className="del" title={`Delete ${name}`} onClick={() => onDeleteSave(name)}>✕</button>
                 </div>
               ))}
@@ -109,11 +128,12 @@ export function MatrixEditor({
             placeholder="Save as…"
             aria-label="Save matchup as"
             value={saveName}
+            disabled={locked}
             onChange={(e) => setSaveName(e.target.value)}
           />
           <button
             className="primary"
-            disabled={!saveName.trim()}
+            disabled={locked || !saveName.trim()}
             onClick={() => { onSaveAs(saveName.trim()); setSaveName(''); }}
           >
             Save
@@ -122,7 +142,7 @@ export function MatrixEditor({
 
         <div className="row">
           <button onClick={doExport}>Export JSON</button>
-          <button onClick={() => fileRef.current?.click()}>Import JSON</button>
+          <button disabled={locked} onClick={() => fileRef.current?.click()}>Import JSON</button>
           <input
             ref={fileRef}
             type="file"
@@ -133,7 +153,7 @@ export function MatrixEditor({
           />
         </div>
 
-        <button onClick={() => setPasteOpen(true)}>Paste from spreadsheet…</button>
+        <button disabled={locked} onClick={() => setPasteOpen(true)}>Paste from spreadsheet…</button>
         {importError && <div className="errors">{importError}</div>}
 
         <p className="privacy">
@@ -142,13 +162,14 @@ export function MatrixEditor({
         </p>
       </aside>
 
-      <div className="editor-main">
+      <div className={locked ? 'editor-main locked' : 'editor-main'}>
         <div className="matchup">
           <input
             className="team-name mine"
             placeholder="Your team"
             aria-label="Your team name"
             value={matrix.myTeam}
+            readOnly={locked}
             onChange={(e) => update({ myTeam: e.target.value })}
           />
           <label>rows · my team</label>
@@ -158,6 +179,7 @@ export function MatrixEditor({
             placeholder="Opponent"
             aria-label="Opponent team name"
             value={matrix.enemyTeam}
+            readOnly={locked}
             onChange={(e) => update({ enemyTeam: e.target.value })}
           />
           <label>columns · opponent</label>
@@ -169,6 +191,7 @@ export function MatrixEditor({
             <select
               value={matrix.n}
               aria-label="Team size"
+              disabled={locked}
               onChange={(e) => onMatrixChange(resize(matrix, Number(e.target.value) as MatrixSize))}
             >
               <option value={4}>4</option>
@@ -181,6 +204,7 @@ export function MatrixEditor({
             <select
               value=""
               aria-label="Load a sample opponent"
+              disabled={locked}
               onChange={(e) => {
                 const sample = SAMPLES.find((s) => s.key === e.target.value);
                 if (sample) onMatrixChange(sample.matrix);
@@ -192,16 +216,16 @@ export function MatrixEditor({
           </label>
           <span className="spacer" />
           <div className="segmented" role="group" aria-label="Rating mode">
-            <button className={settings.simpleMode ? 'on' : ''} onClick={() => onSettingsChange({ ...settings, simpleMode: true })}>
+            <button className={settings.simpleMode ? 'on' : ''} disabled={locked} onClick={() => onSettingsChange({ ...settings, simpleMode: true })}>
               Single rating
             </button>
-            <button className={!settings.simpleMode ? 'on' : ''} onClick={() => onSettingsChange({ ...settings, simpleMode: false })}>
+            <button className={!settings.simpleMode ? 'on' : ''} disabled={locked} onClick={() => onSettingsChange({ ...settings, simpleMode: false })}>
               Best / worst map
             </button>
           </div>
           <button
             onClick={() => { if (validation.ok) onMatrixChange(transpose(matrix)); }}
-            disabled={!validation.ok}
+            disabled={locked || !validation.ok}
             title={validation.ok ? 'Swap which side you captain — transposes the matrix and team names' : 'Fix invalid cells before swapping'}
           >
             ⇄ Swap sides
@@ -212,6 +236,7 @@ export function MatrixEditor({
           matrix={matrix}
           simpleMode={settings.simpleMode}
           cellErrors={validation.cellErrors}
+          readOnly={locked}
           onCellChange={setCell}
           onMyName={setMyName}
           onEnemyName={setEnemyName}
@@ -236,7 +261,7 @@ export function MatrixEditor({
         <div className="solve-bar">
           <button
             className="primary"
-            disabled={!validation.ok || !onSolve}
+            disabled={!validation.ok || !onSolve || locked}
             onClick={onSolve}
             title={onSolve ? undefined : 'Solving arrives with issue #20'}
           >
@@ -247,6 +272,7 @@ export function MatrixEditor({
       </div>
 
       {pasteOpen && <PasteModal n={matrix.n} onApply={applyPaste} onCancel={() => setPasteOpen(false)} />}
-    </div>
+      </div>
+    </>
   );
 }

--- a/web/src/components/MatrixEditor.tsx
+++ b/web/src/components/MatrixEditor.tsx
@@ -116,7 +116,7 @@ export function MatrixEditor({
               {savedNames.map((name) => (
                 <div className="saved-row" key={name}>
                   <button className="load" disabled={locked} onClick={() => onLoadSave(name)}>{name}</button>
-                  <button className="del" title={`Delete ${name}`} onClick={() => onDeleteSave(name)}>✕</button>
+                  <button className="del" disabled={locked} title={`Delete ${name}`} onClick={() => onDeleteSave(name)}>✕</button>
                 </div>
               ))}
             </div>

--- a/web/src/components/PhaseStepper.test.tsx
+++ b/web/src/components/PhaseStepper.test.tsx
@@ -9,5 +9,5 @@ test('marks the active stage and not the others', () => {
   const q = within(container);
   expect(q.getByText('Attackers').className).toMatch(/on/);
   expect(q.getByText('Defenders').className).not.toMatch(/on/);
-  expect(q.getByText('Refusal').className).not.toMatch(/on/);
+  expect(q.getByText('Pairing').className).not.toMatch(/on/);
 });

--- a/web/src/components/PhaseStepper.tsx
+++ b/web/src/components/PhaseStepper.tsx
@@ -5,11 +5,13 @@ interface PhaseStepperProps {
 const STEPS = [
   { key: 'defender', label: 'Defenders' },
   { key: 'attackers', label: 'Attackers' },
-  { key: 'refusal', label: 'Refusal' },
+  { key: 'refusal', label: 'Pairing' },
 ] as const;
 
 /** The round's three steps as a segmented indicator (docs/design-mockup.html
- * "Trainer": Defenders | Attackers | Refusal). The current stage is `.on`. */
+ * "Trainer": Defenders | Attackers | Pairing). The 'refusal' key keeps the
+ * engine's name; the label is user-facing (people think in pairings). Active
+ * stage is `.on`. */
 export function PhaseStepper({ stage }: PhaseStepperProps) {
   return (
     <div className="stepper segmented" role="list" aria-label="Draft phase">

--- a/web/src/components/WhyPanel.test.tsx
+++ b/web/src/components/WhyPanel.test.tsx
@@ -7,20 +7,33 @@ import { DraftEngine } from '../engine/engine';
 import { initDraft } from '../draft/draftState';
 import { WhyPanel } from './WhyPanel';
 
-test('defender stage: shows both the EV-per-choice list and the threat sub-matrix', () => {
+/** A solved Smoke engine plus a fresh draft model at the defender stage. */
+function setup() {
   const matrix = fixtureMatrix(smoke);
-  const model = initDraft(matrix, smoke.neutralWeight);
   const engine = new DraftEngine(matrix, null, smoke.neutralWeight);
   engine.solve();
-  const node = engine.nodeResult([]);
+  return { matrix, engine, model: initDraft(matrix, smoke.neutralWeight) };
+}
 
-  const { container } = render(
-    <WhyPanel node={node} model={model} myNames={matrix.myNames} enemyNames={matrix.enemyNames} />,
-  );
+test('attackers stage: shows the attacker-pair EV list, one row per offered pair', () => {
+  const { matrix, engine } = setup();
+  // Lock an arbitrary defender move to reach an attackers-stage node.
+  const base = initDraft(matrix, smoke.neutralWeight);
+  const myDef = engine.nodeResult([]).choices[0].id as number;
+  const enDef = base.enemyRemaining[0];
+  const model = { ...base, myDefender: myDef, enemyDefender: enDef, path: [{ stage: 'defender' as const, my: myDef, enemy: enDef }] };
+  const node = engine.nodeResult(model.path);
+
+  const { container } = render(<WhyPanel node={node} model={model} />);
   const q = within(container);
-
-  expect(q.getByText(/Team EV per defender choice/i)).toBeInTheDocument();
-  expect(q.getByText(/Score vs their biggest threats/i)).toBeInTheDocument();
-  // One EV row per candidate defender.
+  expect(q.getByText(/Team EV per attacker pair choice/i)).toBeInTheDocument();
   expect(container.querySelectorAll('.ev-table tr').length).toBe(node.choices.length);
+});
+
+test('defender stage: renders nothing — the "why" folds into the per-card hints', () => {
+  const { engine, model } = setup();
+  const node = engine.nodeResult([]);
+  const { container } = render(<WhyPanel node={node} model={model} />);
+  expect(container.querySelector('.why')).toBeNull();
+  expect(container.querySelector('.why-threats')).toBeNull();
 });

--- a/web/src/components/WhyPanel.tsx
+++ b/web/src/components/WhyPanel.tsx
@@ -1,38 +1,30 @@
 import type { NodeResult } from '../engine/types';
 import type { DraftModel } from '../draft/draftState';
-import { topThreats } from '../draft/cards';
-import { formatTeamScore, scoreBand, teamTotal, toScore } from '../model/scale';
+import { formatTeamScore, teamTotal } from '../model/scale';
 
 interface WhyPanelProps {
   node: NodeResult;
   model: DraftModel;
-  myNames: string[];
-  enemyNames: string[];
 }
 
 function joinName(name: string | [string, string]): string {
   return typeof name === 'string' ? name : `${name[0]} + ${name[1]}`;
 }
 
-/** Why the bot plays what it plays (docs/design-mockup.html "WHY THIS PLAY"):
- * a ranked "team EV per choice" bar list, plus — at the defender stage — a small
- * "score vs their biggest threats" sub-matrix (our top candidates × the enemy's
- * top-weighted defenders). Replaces the raw full payoff matrix. */
-export function WhyPanel({ node, model, myNames, enemyNames }: WhyPanelProps) {
-  if (!node.why) return null;
-  const unit = node.stage === 'defender' ? 'defender' : node.stage === 'attackers' ? 'attacker pair' : 'matchup';
+/** The attacker-pair EV breakdown (docs/design-mockup.html "WHY THIS PLAY"),
+ * shown alongside the coaching hints at the attackers stage: every offered pair
+ * ranked by the projected full-draft team score if you send it. This is the
+ * one "why" view that adds something over the per-card hints — the defender and
+ * pairing stages already surface their per-choice EV on the cards, so nothing
+ * extra renders there. */
+export function WhyPanel({ node, model }: WhyPanelProps) {
+  if (!node.why || node.stage !== 'attackers') return null;
 
-  // Each choice's projected full-draft team score = already-fixed games + this
-  // choice's sub-game value (best continuation), converted to the 0–20n scale.
-  // At refusal the cards are framed as who my defender faces (the kept enemy
-  // attacker), so label the rows the same way rather than by the refused one.
+  // Each pair's projected team score = already-fixed games + this pair's sub-game
+  // value (best continuation), on the 0–20n scale, ranked best first.
   const achieved = model.fixed.reduce((sum, g) => sum + g.value, 0);
-  const label = (c: NodeResult['choices'][number]): string =>
-    node.stage === 'refusal'
-      ? enemyNames[model.enemyPair!.find((x) => x !== (c.id as number))!]
-      : joinName(c.name);
   const ranked = node.choices
-    .map((c) => ({ id: c.id, name: label(c), score: teamTotal(achieved + c.ev, model.n) }))
+    .map((c) => ({ name: joinName(c.name), score: teamTotal(achieved + c.ev, model.n) }))
     .sort((a, b) => b.score - a.score);
   const scores = ranked.map((r) => r.score);
   const maxScore = Math.max(...scores);
@@ -40,65 +32,23 @@ export function WhyPanel({ node, model, myNames, enemyNames }: WhyPanelProps) {
   const span = maxScore - minScore || 1;
   const barPct = (score: number): number => 35 + (65 * (score - minScore)) / span;
 
-  const threats = topThreats(model, node, 3);
-  const topRows = ranked.slice(0, 3);
-
   return (
     <div className="why">
-      <div className="why-grid">
-        <div className="why-ev">
-          <div className="section-head">Team EV per {unit} choice</div>
-          <table className="ev-table">
-            <tbody>
-              {ranked.map((r, i) => (
-                <tr key={i}>
-                  <td className="ev-name">{r.name}</td>
-                  <td className="ev-bar">
-                    <span className={i === 0 ? 'top' : ''} style={{ width: `${barPct(r.score)}%` }} />
-                  </td>
-                  <td className="ev-val num">{formatTeamScore(r.score)}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-
-        {node.stage === 'defender' && threats.length > 0 && (
-          <div className="why-threats">
-            <div className="section-head">Score vs their biggest threats</div>
-            <div className="why-scroll">
-              <table className="why-table">
-                <thead>
-                  <tr>
-                    <th className="wcorner" />
-                    {threats.map((t) => (
-                      <th key={t.enemyIndex}>
-                        <span className="wlabel enemy">{enemyNames[t.enemyIndex]}</span>
-                      </th>
-                    ))}
-                  </tr>
-                </thead>
-                <tbody>
-                  {topRows.map((r) => (
-                    <tr key={r.id as number}>
-                      <th className="wrow">
-                        <span className="wlabel mine">{myNames[r.id as number]}</span>
-                      </th>
-                      {threats.map((t) => {
-                        const score = toScore(model.matrix.cells[r.id as number][t.enemyIndex].best);
-                        return (
-                          <td key={t.enemyIndex} className={`num band-${scoreBand(score)}`}>
-                            {score}
-                          </td>
-                        );
-                      })}
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </div>
-        )}
+      <div className="why-ev">
+        <div className="section-head">Team EV per attacker pair choice</div>
+        <table className="ev-table">
+          <tbody>
+            {ranked.map((r, i) => (
+              <tr key={i}>
+                <td className="ev-name">{r.name}</td>
+                <td className="ev-bar">
+                  <span className={i === 0 ? 'top' : ''} style={{ width: `${barPct(r.score)}%` }} />
+                </td>
+                <td className="ev-val num">{formatTeamScore(r.score)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </div>
     </div>
   );

--- a/web/src/components/WhyPanel.tsx
+++ b/web/src/components/WhyPanel.tsx
@@ -20,13 +20,19 @@ function joinName(name: string | [string, string]): string {
  * top-weighted defenders). Replaces the raw full payoff matrix. */
 export function WhyPanel({ node, model, myNames, enemyNames }: WhyPanelProps) {
   if (!node.why) return null;
-  const unit = node.stage === 'defender' ? 'defender' : node.stage === 'attackers' ? 'attacker pair' : 'refusal';
+  const unit = node.stage === 'defender' ? 'defender' : node.stage === 'attackers' ? 'attacker pair' : 'matchup';
 
   // Each choice's projected full-draft team score = already-fixed games + this
   // choice's sub-game value (best continuation), converted to the 0–20n scale.
+  // At refusal the cards are framed as who my defender faces (the kept enemy
+  // attacker), so label the rows the same way rather than by the refused one.
   const achieved = model.fixed.reduce((sum, g) => sum + g.value, 0);
+  const label = (c: NodeResult['choices'][number]): string =>
+    node.stage === 'refusal'
+      ? enemyNames[model.enemyPair!.find((x) => x !== (c.id as number))!]
+      : joinName(c.name);
   const ranked = node.choices
-    .map((c) => ({ id: c.id, name: joinName(c.name), score: teamTotal(achieved + c.ev, model.n) }))
+    .map((c) => ({ id: c.id, name: label(c), score: teamTotal(achieved + c.ev, model.n) }))
     .sort((a, b) => b.score - a.score);
   const scores = ranked.map((r) => r.score);
   const maxScore = Math.max(...scores);

--- a/web/src/components/editor.css
+++ b/web/src/components/editor.css
@@ -2,6 +2,25 @@
 
 .editor { display: flex; gap: 1.25rem; align-items: flex-start; }
 
+/* Draft-in-progress lock: warning banner above the editor + a dimmed, frozen
+ * grid (docs/design-mockup.html). Editing is paused so the running draft's
+ * numbers can't change under it; the only escape is "Discard draft to edit". */
+.draft-lock {
+  display: flex; align-items: center; gap: 0.8rem;
+  padding: 0.7rem 1rem; margin-bottom: 1.25rem;
+  background: #e0914b1a; border: 1px solid #e0914b55; border-radius: var(--radius-sm);
+}
+.draft-lock-dot { width: 0.5rem; height: 0.5rem; border-radius: 2px; background: var(--amber); flex-shrink: 0; }
+.draft-lock-text { flex: 1; font-size: 0.82rem; color: var(--text-2); line-height: 1.5; }
+.draft-lock-discard {
+  flex-shrink: 0; font-weight: 600; font-size: 0.8rem;
+  color: #101418; background: var(--amber); border-color: transparent;
+}
+.draft-lock-discard:hover:not(:disabled) { filter: brightness(1.1); border-color: transparent; }
+
+/* the frozen editing surface: dimmed so it reads as paused, not disabled */
+.editor-main.locked { opacity: 0.45; }
+
 .editor-sidebar {
   flex: 0 0 15rem;
   display: flex; flex-direction: column; gap: 0.75rem;

--- a/web/src/components/trainer.css
+++ b/web/src/components/trainer.css
@@ -51,7 +51,10 @@
 .slot.pending .slot-name, .slot.hidden .slot-name, .slot.empty .slot-name { color: var(--text-4); font-weight: 500; }
 .slot.hidden, .slot.empty { border-style: dashed; }
 .slot.atk.enemy.hidden { border-color: #e0573e55; }
-.slot.active { border-color: var(--blue); box-shadow: 0 0 0 1px var(--blue) inset; }
+/* an in-play slot gets its side's coloured border; a refused attacker dims */
+.slot.mine.on { border-color: var(--blue); box-shadow: 0 0 0 1px var(--blue) inset; }
+.slot.enemy.on { border-color: var(--enemy); box-shadow: 0 0 0 1px var(--enemy) inset; }
+.slot.muted { opacity: 0.5; }
 .slot-pair { display: flex; gap: 0.4rem; }
 .slot-pair .slot { flex: 1; justify-content: center; }
 .board-hint { margin-top: 0.4rem; color: var(--text-4); font-size: 0.78rem; }

--- a/web/src/components/trainer.css
+++ b/web/src/components/trainer.css
@@ -38,23 +38,34 @@
 
 /* --- draft board (docs/design-mockup.html "Trainer") --- */
 .draft-board { display: flex; gap: 1rem; margin-bottom: 1rem; }
-.board-panel { flex: 1; min-width: 0; background: var(--card); border: 1px solid var(--border); border-radius: var(--radius); padding: 0.9rem 1rem; }
+.board-panel { flex: 1; min-width: 0; background: var(--bg-2); border: 1px solid var(--border); border-radius: var(--radius); padding: 0.9rem 1rem; }
 .board-title { font-size: 0.7rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-4); margin-bottom: 0.6rem; }
-.slot { display: flex; align-items: center; gap: 0.6rem; padding: 0.55rem 0.7rem; border: 1px solid var(--border-strong); border-radius: var(--radius-sm); background: var(--bg-2); }
+/* Slots follow the mockup's faction cells: a soft side-tinted fill + a clean 1px
+ * side border for an in-play pick, a faint dashed placeholder otherwise. */
+.slot { display: flex; align-items: center; gap: 0.6rem; padding: 0.55rem 0.7rem; border: 1px solid var(--border-strong); border-radius: var(--radius-sm); background: transparent; }
 .slot .slot-name { font-weight: 600; }
 .slot.def { margin-bottom: 0.5rem; }
 .slot.def .slot-tag { font-family: var(--font-mono); font-size: 0.7rem; font-weight: 700; letter-spacing: 0.06em; padding: 0.1rem 0.35rem; border-radius: 4px; color: #06101c; }
 .slot.mine .slot-tag { background: var(--blue); }
 .slot.enemy .slot-tag { background: var(--enemy); }
-.slot.mine.filled .slot-name { color: var(--blue); }
+
+/* in-play pick (locked or being chosen): soft tint + solid side border */
+.slot.mine.on { background: color-mix(in srgb, var(--blue) 8%, transparent); border-color: var(--blue); }
+.slot.enemy.on { background: color-mix(in srgb, var(--enemy) 8%, transparent); border-color: var(--enemy); }
+.slot.mine.filled .slot-name { color: var(--text); }
 .slot.enemy.filled .slot-name { color: var(--enemy); }
-.slot.pending .slot-name, .slot.hidden .slot-name, .slot.empty .slot-name { color: var(--text-4); font-weight: 500; }
+
+/* refused enemy attacker: stays in the panel, de-emphasised */
+.slot.muted { background: color-mix(in srgb, var(--enemy) 5%, transparent); border-color: color-mix(in srgb, var(--enemy) 30%, transparent); opacity: 0.65; }
+
+/* placeholders — faint dashed. "—" is neutral; the hidden "?" keeps a side tint */
 .slot.hidden, .slot.empty { border-style: dashed; }
-.slot.atk.enemy.hidden { border-color: #e0573e55; }
-/* an in-play slot gets its side's coloured border; a refused attacker dims */
-.slot.mine.on { border-color: var(--blue); box-shadow: 0 0 0 1px var(--blue) inset; }
-.slot.enemy.on { border-color: var(--enemy); box-shadow: 0 0 0 1px var(--enemy) inset; }
-.slot.muted { opacity: 0.5; }
+.slot.empty { border-color: var(--border); }
+.slot.empty .slot-name { color: var(--text-4); font-weight: 500; }
+.slot.def.mine.pending { background: color-mix(in srgb, var(--blue) 5%, transparent); border-style: dashed; border-color: color-mix(in srgb, var(--blue) 40%, transparent); }
+.slot.def.mine.pending .slot-name { color: var(--text-3); font-weight: 500; }
+.slot.enemy.hidden { background: color-mix(in srgb, var(--enemy) 5%, transparent); border-color: color-mix(in srgb, var(--enemy) 40%, transparent); }
+.slot.enemy.hidden .slot-name { color: var(--enemy); font-weight: 500; }
 .slot-pair { display: flex; gap: 0.4rem; }
 .slot-pair .slot { flex: 1; justify-content: center; }
 .board-hint { margin-top: 0.4rem; color: var(--text-4); font-size: 0.78rem; }

--- a/web/src/components/trainer.css
+++ b/web/src/components/trainer.css
@@ -102,8 +102,7 @@
 .lock-bar { display: flex; align-items: center; gap: 0.75rem; margin-top: 1rem; }
 
 .why { margin-top: 1.25rem; }
-.why-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; align-items: start; }
-.why-ev .section-head, .why-threats .section-head { margin-bottom: 0.6rem; }
+.why-ev .section-head { margin-bottom: 0.6rem; }
 .ev-table { width: 100%; border-collapse: collapse; }
 .ev-table td { padding: 0.22rem 0.35rem; vertical-align: middle; }
 .ev-name { white-space: nowrap; color: var(--text-1); }

--- a/web/src/components/trainer.css
+++ b/web/src/components/trainer.css
@@ -57,6 +57,10 @@
 .slot.def.mine.pending .slot-name { color: var(--text-3); font-weight: 500; }
 .slot.enemy.hidden { background: color-mix(in srgb, var(--enemy) 5%, transparent); border-color: color-mix(in srgb, var(--enemy) 40%, transparent); }
 .slot.enemy.hidden .slot-name { color: var(--enemy); font-weight: 500; }
+
+/* final-round auto-pairing preview: neutral LAST cell (grey tag + muted text) */
+.slot.auto .slot-tag { background: var(--text-4); }
+.slot.auto .slot-name { color: var(--text-2); font-weight: 500; }
 .slot-pair { display: flex; gap: 0.4rem; }
 .slot-pair .slot { flex: 1; justify-content: center; }
 .board-hint { margin-top: 0.4rem; color: var(--text-4); font-size: 0.78rem; }

--- a/web/src/components/trainer.css
+++ b/web/src/components/trainer.css
@@ -31,7 +31,7 @@
 .reveal .r-enemy { color: var(--enemy); font-weight: 600; }
 @keyframes wtcFlip { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: none; } }
 
-/* phase stepper (Defenders | Attackers | Refusal) */
+/* phase stepper (Defenders | Attackers | Pairing) */
 .stepper { margin-bottom: 0.75rem; }
 .stepper span { padding: 0.35rem 0.8rem; border-radius: 6px; color: var(--text-4); font-size: 0.85rem; }
 .stepper span.on { background: var(--blue); color: #06101c; font-weight: 600; }

--- a/web/src/components/trainer.css
+++ b/web/src/components/trainer.css
@@ -65,6 +65,8 @@
 .choice.selected { border-color: var(--blue); background: var(--card-2); }
 .choice .cname { font-weight: 600; }
 .choice .cstat { color: var(--text-3); font-size: 0.8rem; }
+/* Show the ratings the way the matrix does: banded colour + mono + bold. */
+.choice .cstat .num { font-weight: 600; }
 .choice .chint { display: flex; align-items: center; gap: 0.5rem; width: 100%; margin-top: 0.15rem; }
 .choice .cbar { flex: 1; height: 0.4rem; background: var(--bg-2); border-radius: 3px; overflow: hidden; }
 .choice .cbar > span { display: block; height: 100%; background: var(--blue); }

--- a/web/src/components/trainer.css
+++ b/web/src/components/trainer.css
@@ -22,15 +22,6 @@
 }
 .wtc-note strong { color: var(--text-1); }
 
-.reveal {
-  display: flex; gap: 1rem; flex-wrap: wrap; padding: 0.6rem 0.9rem; margin-bottom: 1rem;
-  background: var(--card); border: 1px solid var(--border); border-radius: var(--radius-sm);
-  animation: wtcFlip 0.45s ease-out;
-}
-.reveal .r-mine { color: var(--blue); font-weight: 600; }
-.reveal .r-enemy { color: var(--enemy); font-weight: 600; }
-@keyframes wtcFlip { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: none; } }
-
 /* phase stepper (Defenders | Attackers | Pairing) */
 .stepper { margin-bottom: 0.75rem; }
 .stepper span { padding: 0.35rem 0.8rem; border-radius: 6px; color: var(--text-4); font-size: 0.85rem; }

--- a/web/src/components/trainer.css
+++ b/web/src/components/trainer.css
@@ -65,7 +65,11 @@
 }
 .choice:hover:not(:disabled) { border-color: var(--blue); }
 .choice.selected { border-color: var(--blue); background: var(--card-2); }
-.choice .cname { font-weight: 600; }
+.choice .cname { font-weight: 600; display: flex; align-items: center; gap: 0.4rem; }
+/* attackers stage: the ✓ badge on a selected attacker card */
+.choice .cname .tick { margin-left: auto; width: 1.05rem; height: 1.05rem; border-radius: 50%;
+  background: var(--blue); color: #06101c; font-size: 0.72rem; font-weight: 700;
+  display: inline-flex; align-items: center; justify-content: center; }
 .choice .cstat { color: var(--text-3); font-size: 0.8rem; }
 /* Show the ratings the way the matrix does: banded colour + mono + bold. */
 .choice .cstat .num { font-weight: 600; }
@@ -74,6 +78,17 @@
 .choice .cbar > span { display: block; height: 100%; background: var(--blue); }
 .choice .cprob { color: var(--text-2); font-family: var(--font-mono); font-size: 0.82rem; }
 .choice .cev { color: var(--text-3); font-family: var(--font-mono); font-size: 0.82rem; }
+.choice .csend { color: var(--text-3); font-family: var(--font-mono); font-size: 0.82rem; white-space: nowrap; }
+
+/* attackers stage: the picked-pair equilibrium share + EV, shown once two
+ * attackers are selected (the pair-defined figures the cards can't carry). */
+.pair-summary { display: flex; align-items: center; gap: 0.4rem 0.9rem; flex-wrap: wrap;
+  margin-top: 0.6rem; padding: 0.55rem 0.9rem; background: var(--card);
+  border: 1px solid var(--blue); border-radius: var(--radius-sm); font-size: 0.85rem; }
+.pair-summary .ps-label { color: var(--text-4); text-transform: uppercase; font-size: 0.7rem; letter-spacing: 0.05em; }
+.pair-summary .ps-names { color: var(--blue); font-weight: 600; }
+.pair-summary .ps-fig { font-family: var(--font-mono); color: var(--text-1); }
+.pair-summary .ps-regret { color: var(--amber); font-family: var(--font-mono); }
 
 .lock-bar { display: flex; align-items: center; gap: 0.75rem; margin-top: 1rem; }
 

--- a/web/src/components/trainer.css
+++ b/web/src/components/trainer.css
@@ -10,9 +10,11 @@
 .trainer-head .projected .pdelta.down { color: var(--amber); }
 .trainer-sub { color: var(--text-3); margin-bottom: 1rem; }
 
-.trainer-controls { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; margin-bottom: 1rem; }
-.trainer-controls .spacer { flex: 1; }
-.style-select { display: flex; align-items: center; gap: 0.4rem; color: var(--text-3); font-size: 0.85rem; }
+/* stepper on the left, coaching + undo controls pushed to the right; wraps
+ * below the stepper on narrow screens. */
+.trainer-topbar { display: flex; align-items: center; gap: 0.75rem 1rem; flex-wrap: wrap; margin-bottom: 0.75rem; }
+.trainer-topbar .stepper { margin-bottom: 0; }
+.trainer-controls { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; margin-left: auto; }
 
 .wtc-note {
   padding: 0.55rem 0.9rem; margin-bottom: 1rem; font-size: 0.85rem; color: var(--amber);

--- a/web/src/components/trainer.css
+++ b/web/src/components/trainer.css
@@ -148,9 +148,14 @@
 .decomp .metric { background: var(--card); border: 1px solid var(--border); border-radius: var(--radius); padding: 0.8rem 1rem; text-align: center; }
 .decomp .metric .mval { font-family: var(--font-mono); font-size: 1.6rem; font-weight: 700; }
 .decomp .metric .mlabel { color: var(--text-3); font-size: 0.82rem; }
-.leaks-list { display: flex; flex-direction: column; gap: 0.3rem; }
-.leak { padding: 0.4rem 0.7rem; background: var(--card); border: 1px solid var(--border); border-radius: var(--radius-sm); font-size: 0.88rem; }
-.leak .lcost { color: var(--red-soft); font-family: var(--font-mono); }
+.history { display: flex; flex-direction: column; gap: 0.3rem; }
+.hrow { display: flex; align-items: baseline; gap: 0.4rem 0.75rem; flex-wrap: wrap;
+  padding: 0.4rem 0.7rem; background: var(--card); border: 1px solid var(--border); border-radius: var(--radius-sm); font-size: 0.88rem; }
+.hrow .hbest { color: var(--text-4); font-size: 0.82rem; }
+.hrow .hval { margin-left: auto; font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
+.hrow .hval.opt { color: var(--green); }
+.hrow .hval.minor { color: var(--amber); }
+.hrow .hval.major { color: var(--red-soft); }
 .summary-actions { display: flex; gap: 0.75rem; margin-top: 1.25rem; }
 
 @media (max-width: 640px) { .decomp { grid-template-columns: 1fr; } }

--- a/web/src/draft/cards.test.ts
+++ b/web/src/draft/cards.test.ts
@@ -2,7 +2,19 @@ import { describe, expect, test } from 'vitest';
 import { fixtureMatrix, smoke } from '../conformance/fixtures';
 import { DraftEngine } from '../engine/engine';
 import { initDraft } from './draftState';
-import { candidateStats, projectedResult, topThreats } from './cards';
+import { attackerOptions, candidateStats, pairChoiceIndex, projectedResult, topThreats } from './cards';
+
+/** Lock an arbitrary defender move to reach an attackers-stage node. */
+function attackersNode() {
+  const matrix = fixtureMatrix(smoke);
+  const engine = new DraftEngine(matrix, null, smoke.neutralWeight);
+  engine.solve();
+  let model = initDraft(matrix, smoke.neutralWeight);
+  const myDef = engine.nodeResult([]).choices[0].id as number;
+  const enDef = model.enemyRemaining[0];
+  model = { ...model, myDefender: myDef, enemyDefender: enDef, path: [{ stage: 'defender', my: myDef, enemy: enDef }] };
+  return { matrix, model, myDef, enDef, node: engine.nodeResult(model.path) };
+}
 
 describe('candidateStats', () => {
   test('defender stage: avg + floor of my row over enemy remaining (best map)', () => {
@@ -42,6 +54,47 @@ describe('candidateStats', () => {
     const vals = [matrix.cells[a][enDef].worst + 10, matrix.cells[b][enDef].worst + 10];
     expect(s.floor).toBe(Math.min(...vals));
     expect(s.avg).toBe(Math.round((vals[0] + vals[1]) / 2));
+  });
+});
+
+describe('attackerOptions', () => {
+  test('one option per eligible attacker, worst-map rating, marginal send-prob', () => {
+    const { matrix, model, myDef, enDef, node } = attackersNode();
+    const opts = attackerOptions(model, node);
+
+    // Eligible attackers = my remaining minus my defender, ascending.
+    const eligible = model.myRemaining.filter((x) => x !== myDef).sort((a, b) => a - b);
+    expect(opts.map((o) => o.index)).toEqual(eligible);
+
+    for (const o of opts) {
+      // Rating = worst-map value vs the enemy defender, on the 0–20 scale.
+      expect(o.rating).toBe(matrix.cells[o.index][enDef].worst + 10);
+      // Marginal = summed prob of every offered pair containing the attacker.
+      const marginal = node.choices
+        .filter((c) => (c.id as [number, number]).includes(o.index))
+        .reduce((s, c) => s + c.prob, 0);
+      expect(o.sendProb).toBeCloseTo(marginal, 12);
+    }
+    // Two attackers are sent, so the marginals total 2.
+    expect(opts.reduce((s, o) => s + o.sendProb, 0)).toBeCloseTo(2, 6);
+  });
+
+  test('empty off the attackers stage', () => {
+    const matrix = fixtureMatrix(smoke);
+    const model = initDraft(matrix, smoke.neutralWeight);
+    const engine = new DraftEngine(matrix, null, smoke.neutralWeight);
+    engine.solve();
+    expect(attackerOptions(model, engine.nodeResult([]))).toEqual([]); // a defender node
+  });
+});
+
+describe('pairChoiceIndex', () => {
+  test('matches an offered pair either order; −1 when the pair is not offered', () => {
+    const { model, myDef, node } = attackersNode();
+    const [a, b] = node.choices[0].id as [number, number];
+    expect(pairChoiceIndex(node, a, b)).toBe(0);
+    expect(pairChoiceIndex(node, b, a)).toBe(0); // order-independent
+    expect(pairChoiceIndex(node, myDef, model.myRemaining.filter((x) => x !== myDef)[0])).toBe(-1);
   });
 });
 

--- a/web/src/draft/cards.test.ts
+++ b/web/src/draft/cards.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'vitest';
 import { fixtureMatrix, smoke } from '../conformance/fixtures';
 import { DraftEngine } from '../engine/engine';
 import { initDraft } from './draftState';
-import { attackerOptions, candidateStats, pairChoiceIndex, projectedResult, topThreats } from './cards';
+import { attackerOptions, candidateStats, pairChoiceIndex, projectedResult } from './cards';
 
 /** Lock an arbitrary defender move to reach an attackers-stage node. */
 function attackersNode() {
@@ -111,34 +111,5 @@ describe('projectedResult', () => {
     // The best pure response against the equilibrium mix equals the game value.
     expect(projected).toBeCloseTo(expected, 6);
     expect(delta).toBeCloseTo(0, 6);
-  });
-});
-
-describe('topThreats', () => {
-  test('defender stage: top-k enemy remaining by equilibrium weight, descending', () => {
-    const matrix = fixtureMatrix(smoke);
-    const model = initDraft(matrix, smoke.neutralWeight);
-    const engine = new DraftEngine(matrix, null, smoke.neutralWeight);
-    engine.solve();
-    const node = engine.nodeResult([]);
-
-    const threats = topThreats(model, node, 2);
-    expect(threats.length).toBeLessThanOrEqual(2);
-    const weights = threats.map((t) => t.weight);
-    expect([...weights].sort((a, b) => b - a)).toEqual(weights); // already descending
-    expect(model.enemyRemaining).toContain(threats[0].enemyIndex);
-  });
-
-  test('non-defender stages return no threats', () => {
-    const matrix = fixtureMatrix(smoke);
-    const engine = new DraftEngine(matrix, null, smoke.neutralWeight);
-    engine.solve();
-    let model = initDraft(matrix, smoke.neutralWeight);
-    const root = engine.nodeResult([]);
-    const myDef = root.choices[0].id as number;
-    const enDef = model.enemyRemaining[0];
-    model = { ...model, myDefender: myDef, enemyDefender: enDef, path: [{ stage: 'defender', my: myDef, enemy: enDef }] };
-    const node = engine.nodeResult(model.path);
-    expect(topThreats(model, node)).toEqual([]);
   });
 });

--- a/web/src/draft/cards.ts
+++ b/web/src/draft/cards.ts
@@ -101,22 +101,3 @@ export function pairChoiceIndex(node: NodeResult, x: number, y: number): number 
     return Math.min(a, b) === lo && Math.max(a, b) === hi;
   });
 }
-
-export interface Threat {
-  enemyIndex: number;
-  label: string;
-  weight: number;
-}
-
-/** The enemy's biggest threats at the defender stage: their equilibrium defender
- * mix (`node.why.enStrategy`) ranked descending, top-k. At this stage
- * `colLabels[j]` maps 1:1 to `model.enemyRemaining[j]`. Empty for non-defender
- * stages — the threat sub-matrix is defender-specific. */
-export function topThreats(model: DraftModel, node: NodeResult, k = 3): Threat[] {
-  if (node.stage !== 'defender' || !node.why) return [];
-  const why = node.why;
-  return why.colLabels
-    .map((label, j) => ({ enemyIndex: model.enemyRemaining[j], label, weight: why.enStrategy[j] }))
-    .sort((a, b) => b.weight - a.weight)
-    .slice(0, k);
-}

--- a/web/src/draft/cards.ts
+++ b/web/src/draft/cards.ts
@@ -58,6 +58,50 @@ export function projectedResult(
   return { projected, delta: projected - expected };
 }
 
+export interface AttackerOption {
+  /** Player index (matrix row / myNames position). */
+  index: number;
+  /** Worst-map expected score (0–20) vs the enemy defender. They defend the
+   * game my attackers play into, so this is my worst map. */
+  rating: number;
+  /** Marginal equilibrium probability this attacker is one of the two sent: the
+   * summed weight of every offered pair that contains it (0–1). Across all
+   * attackers these sum to 2 (each pair sends two). */
+  sendProb: number;
+}
+
+/** Per-attacker cards for the attackers stage. Each eligible attacker (the union
+ * of the offered pairs, ascending) with its worst-map rating vs the enemy
+ * defender and its marginal send probability. The equilibrium mixes over *pairs*
+ * (node.choices); the marginal reads better on independent cards than the raw
+ * pair weights. Empty off the attackers stage. */
+export function attackerOptions(model: DraftModel, node: NodeResult): AttackerOption[] {
+  if (node.stage !== 'attackers') return [];
+  const d = model.enemyDefender;
+  const cells = model.matrix.cells;
+  const sent = new Map<number, number>();
+  for (const c of node.choices) {
+    const [a, b] = c.id as [number, number];
+    sent.set(a, (sent.get(a) ?? 0) + c.prob);
+    sent.set(b, (sent.get(b) ?? 0) + c.prob);
+  }
+  return [...sent.keys()]
+    .sort((x, y) => x - y)
+    .map((index) => ({ index, rating: toScore(cells[index][d].worst), sendProb: sent.get(index)! }));
+}
+
+/** Index into node.choices of the offered pair equal to the unordered {x, y}, or
+ * −1 if that pair isn't offered (only possible under k-restriction; an exact
+ * solve offers every pair). */
+export function pairChoiceIndex(node: NodeResult, x: number, y: number): number {
+  const lo = Math.min(x, y);
+  const hi = Math.max(x, y);
+  return node.choices.findIndex((c) => {
+    const [a, b] = c.id as [number, number];
+    return Math.min(a, b) === lo && Math.max(a, b) === hi;
+  });
+}
+
 export interface Threat {
   enemyIndex: number;
   label: string;

--- a/web/src/draft/draftState.ts
+++ b/web/src/draft/draftState.ts
@@ -1,4 +1,4 @@
-import type { Matrix, Move, NodeResult } from '../engine/types';
+import type { Matrix, Move, NodeChoice, NodeResult } from '../engine/types';
 
 /** One of the 8 games fixed by the draft, with its value-model value (internal
  * scale). `my`/`enemy` are player indices. */
@@ -104,14 +104,19 @@ export function applyStep(model: DraftModel, node: NodeResult, myIndex: number, 
   const choice = node.choices[myIndex];
   const bestChoice = node.choices.reduce((best, c) => (c.ev > best.ev ? c : best), node.choices[0]);
   const bestEv = bestChoice.ev;
+  // At the refusal stage a choice picks which enemy attacker to REFUSE, but the
+  // trainer frames it as who my defender FACES (the kept one), so the decision
+  // log records the faced attacker — the other of the two offered.
+  const facedName = (c: NodeChoice): string | [string, string] =>
+    node.stage === 'refusal' ? (node.choices.find((o) => o !== c) ?? c).name : c.name;
   const decision: DraftDecision = {
     stage: node.stage as DraftDecision['stage'],
     round: model.round,
     chosenId: choice.id,
-    chosenName: choice.name,
+    chosenName: facedName(choice),
     chosenEv: choice.ev,
     bestEv,
-    bestName: bestChoice.name,
+    bestName: facedName(bestChoice),
     regret: bestEv - choice.ev,
   };
 

--- a/web/src/model/scale.test.ts
+++ b/web/src/model/scale.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { formatCell, formatTeamScore, parseRating, scoreBand, teamResult, teamTotal, toInputString, toScore } from './scale';
+import { formatCell, formatMatchupScore, formatTeamScore, parseRating, scoreBand, teamResult, teamTotal, toInputString, toScore } from './scale';
 
 describe('parseRating', () => {
   test('legacy tokens map to internal deviations from an even game', () => {
@@ -95,6 +95,20 @@ describe('teamTotal / formatTeamScore', () => {
     expect(formatTeamScore(86)).toBe('86.0');
     expect(formatTeamScore(45)).toBe('45.0');
     expect(formatTeamScore(44.94)).toBe('44.9'); // rounds to one decimal
+  });
+});
+
+describe('formatMatchupScore', () => {
+  test('a map-determined (integer) game shows as a whole number', () => {
+    expect(formatMatchupScore(10)).toBe('10');
+    expect(formatMatchupScore(7)).toBe('7');
+    expect(formatMatchupScore(0)).toBe('0');
+    expect(formatMatchupScore(20)).toBe('20');
+  });
+
+  test('a neutral 50/50 half-step keeps its one decimal', () => {
+    expect(formatMatchupScore(12.5)).toBe('12.5');
+    expect(formatMatchupScore(7.5)).toBe('7.5');
   });
 });
 

--- a/web/src/model/scale.ts
+++ b/web/src/model/scale.ts
@@ -72,6 +72,12 @@ export const teamTotal = (margin: number, n: number): number => 10 * n + margin;
  * read as the same number. */
 export const formatTeamScore = (total: number): string => total.toFixed(1);
 
+/** Format a single game's 0–20 score. A map-determined game (played on a known
+ * map) is an integer and shows as a whole number; a neutral 50/50 game (refused
+ * / last players) can be a half-step and keeps its one decimal. */
+export const formatMatchupScore = (score: number): string =>
+  Number.isInteger(score) ? String(score) : score.toFixed(1);
+
 export type ScoreBand = 'worst' | 'bad' | 'okay' | 'good' | 'best';
 
 /** Colour band for a 0-20 score, per the editor legend: worst ≤4, bad 5-8,

--- a/web/src/model/validation.test.ts
+++ b/web/src/model/validation.test.ts
@@ -39,6 +39,15 @@ describe('validateMatrix', () => {
     expect(r.cellErrors[1][2]).toBeTruthy();
   });
 
+  test('flags a non-integer map value (a game is played on a single map)', () => {
+    const m = valid4();
+    m.cells[0][0] = { b: '12.5', w: '9' };
+    const r = validateMatrix(m);
+    expect(r.ok).toBe(false);
+    expect(r.cellErrors[0][0]).toMatch(/whole number/i);
+    expect(r.cellErrors[0][1]).toBeNull();
+  });
+
   test('flags a blank (incomplete) cell', () => {
     const m = valid4();
     m.cells[2][2] = { b: '', w: '5' };

--- a/web/src/model/validation.ts
+++ b/web/src/model/validation.ts
@@ -22,6 +22,9 @@ function cellError(cell: EditorCell): string | null {
   } catch (error) {
     return `Worst map: ${(error as Error).message}`;
   }
+  // A single game is played on one map, so its score is a whole number.
+  if (!Number.isInteger(best)) return `Best map (${toScore(best)}) must be a whole number.`;
+  if (!Number.isInteger(worst)) return `Worst map (${toScore(worst)}) must be a whole number.`;
   if (best < worst) {
     return `Best map (${toScore(best)}) must be ≥ worst map (${toScore(worst)}).`;
   }


### PR DESCRIPTION
A series of UI/UX fixes for the web draft trainer (`web/`), bringing it in line
with `docs/design-mockup.html`. 13 topical commits; highlights grouped below.

## Draft flow & trainer UX
- Independent attacker cards at the attackers stage (instead of pre-baked pair cards).
- Reframed the refusal step as "choose whom your defender faces" with an "X faces Y" confirm; tab renamed **Pairing**.
- Dropped the bot-style selector; trainer controls lifted onto the stepper row.
- Live draft board: fills + highlights in-progress picks, dims the refused; board slots match the mockup's faction cells.
- Final round shows an "auto-paired this round" board panel.

## Solve, maps & inputs
- On-demand solve, integer matchup results, per-pairing maps, integer input.
- Trainer card ratings banded like the matrix.

## Summary
- Map per pairing + full chronological pick history.

## This session's two topics
- **Draft persists across tab switches.** `DraftTrainer` stays mounted for the session (hidden off-tab) instead of unmounting, so switching Matrix/Solver/Trainer mid-draft no longer resets it. While a draft is live the Matrix tab locks (banner + read-only dimmed grid + disabled controls); "Discard draft to edit" clears the draft and resets the solver, no confirm.
- **"Why" folded into hints.** Removed the separate Why toggle — the one non-redundant view ("Team EV per attacker pair choice") now shows with hints at the attackers stage. Dropped the two redundant per-choice EV panels and the misleading "Score vs their biggest threats" sub-matrix.

## Testing
- `npm --prefix web run typecheck` clean; full web suite green (110 passed, 2 date-gated skips run in CI).
- The tab-persistence lock/discard flow and the Why→hints fold verified end-to-end in a browser preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
